### PR TITLE
[s4u] add static method to create new  actors.

### DIFF
--- a/examples/s4u/basic/s4u_basic.cpp
+++ b/examples/s4u/basic/s4u_basic.cpp
@@ -9,10 +9,9 @@
 
 XBT_LOG_NEW_DEFAULT_CATEGORY(s4u_test, "a sample log category");
 
-class Worker : simgrid::s4u::Actor {
+class Worker : public simgrid::s4u::Actor {
 public:
-  Worker(const char*procname, simgrid::s4u::Host *host,int argc, char **argv)
-      : simgrid::s4u::Actor(procname,host,argc,argv){}
+  Worker() {}
 
   int main(int argc, char **argv) {
     XBT_INFO("Hello s4u, I'm ready to serve");
@@ -24,10 +23,9 @@ public:
   }
 };
 
-class Master : simgrid::s4u::Actor {
+class Master : public simgrid::s4u::Actor {
 public:
-  Master(const char*procname, simgrid::s4u::Host *host,int argc, char **argv)
-      : Actor(procname,host,argc,argv){}
+  Master(){}
 
   int main(int argc, char **argv) {
     const char *msg = "GaBuZoMeu";
@@ -43,9 +41,10 @@ public:
 int main(int argc, char **argv) {
   simgrid::s4u::Engine *e = new simgrid::s4u::Engine(&argc,argv);
   e->loadPlatform("../../platforms/two_hosts_platform.xml");
+  
+  simgrid::s4u::Actor::createActor<Worker>("worker", simgrid::s4u::Host::by_name("host0"), 0, NULL);
+  simgrid::s4u::Actor::createActor<Master>("master", simgrid::s4u::Host::by_name("host1"), 0, NULL);
 
-  new Worker("worker", simgrid::s4u::Host::by_name("host0"), 0, NULL);
-  new Master("master", simgrid::s4u::Host::by_name("host1"), 0, NULL);
   e->run();
   return 0;
 }

--- a/examples/s4u/io/s4u_io.cpp
+++ b/examples/s4u/io/s4u_io.cpp
@@ -11,10 +11,9 @@
 
 XBT_LOG_NEW_DEFAULT_CATEGORY(s4u_test, "a sample log category");
 
-class myHost : simgrid::s4u::Actor {
+class myHost : public simgrid::s4u::Actor {
 public:
-  myHost(const char*procname, simgrid::s4u::Host *host,int argc, char **argv)
-: simgrid::s4u::Actor(procname,host,argc,argv){}
+  myHost(){}
 
   void show_info(boost::unordered_map <std::string, simgrid::s4u::Storage*> const&mounts) {
     XBT_INFO("Storage info on %s:",
@@ -109,7 +108,7 @@ int main(int argc, char **argv) {
   simgrid::s4u::Engine *e = new simgrid::s4u::Engine(&argc,argv);
   e->loadPlatform("../../platforms/storage/storage.xml");
 
-  new myHost("host", simgrid::s4u::Host::by_name("denise"), 0, NULL);
+  simgrid::s4u::Actor::createActor<myHost>("host", simgrid::s4u::Host::by_name("denise"), 0, NULL);
   e->run();
   return 0;
 }

--- a/include/simgrid/s4u/actor.hpp
+++ b/include/simgrid/s4u/actor.hpp
@@ -54,14 +54,14 @@ public:
   
   /** Method to create a new actor, the template parameter must extend the class Actor. In addition  the inheritance must be public. */
   template<class ActorSubClass> static ActorSubClass *createActor(const char*name, s4u::Host *host, int argc, char **argv, double killTime) {
-     Actor *res = dynamic_cast<Actor*>(new ActorSubClass());
+     ActorSubClass *res = new ActorSubClass();
      xbt_assert(res,"The actor class must extends the class simgrid::s4u::Actor.");
      
-     res->pimpl_ = simcall_process_create(name, s4u_actor_runner, static_cast<void*>(res), host->name().c_str(), killTime, argc, argv, NULL/*properties*/,1);
+     static_cast<Actor*>(res)->pimpl_ = simcall_process_create(name, s4u_actor_runner, static_cast<void*>(res), host->name().c_str(), killTime, argc, argv, NULL/*properties*/,1);
      xbt_assert(res->pimpl_,"Cannot create the actor");
    //  TRACE_msg_process_create(procname, simcall_process_get_PID(p_smx_process), host->getInferior());
    //  simcall_process_on_exit(p_smx_process,(int_f_pvoid_pvoid_t)TRACE_msg_process_kill,p_smx_process);
-     return dynamic_cast<ActorSubClass*>(res);
+     return res;
   };
   
   Actor();

--- a/src/s4u/s4u_actor.cpp
+++ b/src/s4u/s4u_actor.cpp
@@ -15,9 +15,10 @@
 XBT_LOG_NEW_DEFAULT_CATEGORY(s4u_actor,"S4U actors");
 
 /* C main function of a actor, running this->main */
-static int s4u_actor_runner(int argc, char **argv)
+int s4u_actor_runner(int argc, char **argv)
 {
-  simgrid::s4u::Actor *actor = (simgrid::s4u::Actor*) SIMIX_process_self_get_data();
+  simgrid::s4u::Actor *actor = static_cast<simgrid::s4u::Actor*>(SIMIX_process_self_get_data());
+  actor->pimpl_ = SIMIX_process_self();
   int res = actor->main(argc,argv);
   return res;
 }
@@ -26,18 +27,10 @@ static int s4u_actor_runner(int argc, char **argv)
 
 using namespace simgrid;
 
-s4u::Actor::Actor(smx_process_t smx_proc) {
-  pimpl_ = smx_proc;
+s4u::Actor::Actor(smx_process_t smx_proc) : pimpl_(smx_proc) {
 }
-s4u::Actor::Actor(const char *name, s4u::Host *host, int argc, char **argv)
-    : s4u::Actor::Actor(name,host, argc,argv, -1) {
-}
-s4u::Actor::Actor(const char *name, s4u::Host *host, int argc, char **argv, double killTime) {
-  pimpl_ = simcall_process_create(name, s4u_actor_runner, this, host->name().c_str(), killTime, argc, argv, NULL/*properties*/,0);
 
-  xbt_assert(pimpl_,"Cannot create the actor");
-//  TRACE_msg_process_create(procname, simcall_process_get_PID(p_smx_process), host->getInferior());
-//  simcall_process_on_exit(p_smx_process,(int_f_pvoid_pvoid_t)TRACE_msg_process_kill,p_smx_process);
+s4u::Actor::Actor() : pimpl_(NULL) { 
 }
 
 int s4u::Actor::main(int argc, char **argv) {


### PR DESCRIPTION
Hi, 
In s4u, when we create an actor (with the c++ constructor), the `simcall_process_create` function is called inside the constructor. The method `main`  of an actor is a virtual function of actor.  This method is called into `simcall_process_create` before it returns. It lead to a case where a virtual function is called inside of the constructor of a derived class. The results is that the method  `main` called when we create a process is the method of the base class.  
This pull request adds a static function `createActor` to create new actor. This method creates an object of actor in the first place and then calls `simcall_process_create`. 
The limitation is that the new actor class must **publicly** inherit from the actor.