### PR TITLE
Add a return value for MSG_sem_get_capacity

### DIFF
--- a/include/simgrid/msg.h
+++ b/include/simgrid/msg.h
@@ -505,7 +505,7 @@ XBT_PUBLIC(msg_sem_t) MSG_sem_init(int initial_value);
 XBT_PUBLIC(void) MSG_sem_acquire(msg_sem_t sem);
 XBT_PUBLIC(msg_error_t) MSG_sem_acquire_timeout(msg_sem_t sem, double timeout);
 XBT_PUBLIC(void) MSG_sem_release(msg_sem_t sem);
-XBT_PUBLIC(void) MSG_sem_get_capacity(msg_sem_t sem);
+XBT_PUBLIC(int) MSG_sem_get_capacity(msg_sem_t sem);
 XBT_PUBLIC(void) MSG_sem_destroy(msg_sem_t sem);
 XBT_PUBLIC(int) MSG_sem_would_block(msg_sem_t sem);
 

--- a/src/msg/msg_synchro.cpp
+++ b/src/msg/msg_synchro.cpp
@@ -46,8 +46,8 @@ void MSG_sem_release(msg_sem_t sem) {
   simcall_sem_release(sem);
 }
 
-void MSG_sem_get_capacity(msg_sem_t sem) {
-  simcall_sem_get_capacity(sem);
+int MSG_sem_get_capacity(msg_sem_t sem) {
+  return simcall_sem_get_capacity(sem);
 }
 
 void MSG_sem_destroy(msg_sem_t sem) {


### PR DESCRIPTION
There were no way of getting the value of the semaphore with MSG_sem_get_capacity.