### PR TITLE
Add smpi_execute_public

### DIFF
--- a/include/smpi/smpi.h
+++ b/include/smpi/smpi.h
@@ -843,6 +843,7 @@ XBT_PUBLIC(void) smpi_process_set_user_data(void *);
 
 XBT_PUBLIC(void) smpi_execute_flops(double flops);
 XBT_PUBLIC(void) smpi_execute(double duration);
+XBT_PUBLIC(void) smpi_execute_public(double duration);
 
 XBT_PUBLIC(double) smpi_get_host_power_peak_at(int pstate_index);
 XBT_PUBLIC(double) smpi_get_host_current_power_peak();

--- a/include/smpi/smpi.h
+++ b/include/smpi/smpi.h
@@ -843,7 +843,7 @@ XBT_PUBLIC(void) smpi_process_set_user_data(void *);
 
 XBT_PUBLIC(void) smpi_execute_flops(double flops);
 XBT_PUBLIC(void) smpi_execute(double duration);
-XBT_PUBLIC(void) smpi_execute_public(double duration);
+XBT_PUBLIC(void) smpi_execute_benched(double duration);
 
 XBT_PUBLIC(double) smpi_get_host_power_peak_at(int pstate_index);
 XBT_PUBLIC(double) smpi_get_host_current_power_peak();

--- a/src/smpi/smpi_bench.cpp
+++ b/src/smpi/smpi_bench.cpp
@@ -78,10 +78,11 @@ void smpi_execute(double duration)
   }
 }
 
-void smpi_execute_public(double duration) {
-    smpi_bench_end();
-    smpi_execute(duration);
-    smpi_bench_begin();
+void smpi_execute_public(double duration)
+{
+  smpi_bench_end();
+  smpi_execute(duration);
+  smpi_bench_begin();
 }
 
 void smpi_bench_begin()

--- a/src/smpi/smpi_bench.cpp
+++ b/src/smpi/smpi_bench.cpp
@@ -78,7 +78,7 @@ void smpi_execute(double duration)
   }
 }
 
-void smpi_execute_public(double duration)
+void smpi_execute_benched(double duration)
 {
   smpi_bench_end();
   smpi_execute(duration);

--- a/src/smpi/smpi_bench.cpp
+++ b/src/smpi/smpi_bench.cpp
@@ -78,6 +78,12 @@ void smpi_execute(double duration)
   }
 }
 
+void smpi_execute_public(double duration) {
+    smpi_bench_end();
+    smpi_execute(duration);
+    smpi_bench_begin();
+}
+
 void smpi_bench_begin()
 {
   if (smpi_privatize_global_variables == SMPI_PRIVATIZE_MMAP) {


### PR DESCRIPTION
This function simply calls `smpi_execute`, but take care of stopping and restarting the bench.

It is useful to replace expensive pieces of application code that cannot be wrapped by a `SMPI_SAMPLE` because of their irregularity. For instance, in HPL, we use it to simulate `dgemm` and `dtrsm`.

Before that, we used `smpi_usleep`, but this one has two drawbacks:
- It takes a virtual time and not a real time, so you have to redo your linear regression each time you change the speed of the platform you simulate.
- It is a sleep, so it works for time estimation but not for energy.

Regarding the name of the function, I am not sure it is very explicit, but I had no better idea.