### PR TITLE
Add support for huge pages in SMPI

### DIFF
--- a/doc/doxygen/options.doc
+++ b/doc/doxygen/options.doc
@@ -1141,6 +1141,8 @@ at least one huge page:
     sudo sh -c 'echo 1 > /proc/sys/vm/nr_hugepages'
 \endcode
 
+Note that at least one huge page is required for smpirun, but you can set
+an higher number of huge pages in nr_hugepages (e.g. "echo 27").
 Then, you can pass the option --cfg=smpi/shared-malloc-hugepage:/home/huge
 to smpirun.
 

--- a/doc/doxygen/options.doc
+++ b/doc/doxygen/options.doc
@@ -1115,6 +1115,35 @@ only consume 1 MiB in memory.
 You can disable this behavior and come back to regular mallocs (for
 example for debugging purposes) using \c "no" as a value.
 
+If you want to keep private some parts of the buffer, for instance if these
+parts are used by the application logic and should not be corrupted, you
+can use SMPI_PARTIAL_SHARED_MALLOC(size, offsets, offsets_count).
+
+As an example,
+
+\code{.unparsed}
+    mem = SMPI_PARTIAL_SHARED_MALLOC(500, {27,42 , 100,200}, 2);
+\endcode
+
+will allocate 500 bytes to mem, such that mem[27..41] and mem[100..199]
+are shared and other area remain private.
+
+Then, it can be deallocated by calling SMPI_SHARED_FREE(mem).
+
+When smpi/shared-malloc:global is used, it is possible to optimize even
+further the memory consumption and the simulation time by using huge pages.
+To do so, it is required to mount a hugetlbfs on your system and allocate
+at least one huge page:
+
+\code{.unparsed}
+    mkdir /home/huge
+    sudo mount none /home/huge -t hugetlbfs -o rw,mode=0777
+    sudo sh -c 'echo 1 > /proc/sys/vm/nr_hugepages'
+\endcode
+
+Then, you can pass the option --cfg=smpi/shared-malloc-hugepage:/home/huge
+to smpirun.
+
 \subsection options_model_smpi_wtime smpi/wtime: Inject constant times for calls to MPI_Wtime
 
 \b Default value: 0

--- a/src/simgrid/sg_config.cpp
+++ b/src/simgrid/sg_config.cpp
@@ -486,6 +486,8 @@ void sg_config_init(int *argc, char **argv)
     xbt_cfg_register_alias("smpi/shared-malloc", "smpi/use-shared-malloc");
     xbt_cfg_register_alias("smpi/shared-malloc", "smpi/use_shared_malloc");
     xbt_cfg_register_double("smpi/shared-malloc-blocksize", 1UL << 20, nullptr, "Size of the bogus file which will be created for global shared allocations");
+    xbt_cfg_register_string("smpi/shared-malloc-hugepage", "", nullptr,
+                            "Path to a mounted hugetlbfs, to use huge pages with shared malloc.");
 
     xbt_cfg_register_double("smpi/cpu-threshold", 1e-6, nullptr, "Minimal computation time (in seconds) not discarded, or -1 for infinity.");
     xbt_cfg_register_alias("smpi/cpu-threshold", "smpi/cpu_threshold");

--- a/src/smpi/smpi_shared.cpp
+++ b/src/smpi/smpi_shared.cpp
@@ -224,14 +224,14 @@ static void *smpi_shared_malloc_local(size_t size, const char *file, int line)
 void* smpi_shared_malloc_partial(size_t size, size_t* shared_block_offsets, int nb_shared_blocks)
 {
   char *huge_page_mount_point = xbt_cfg_get_string("smpi/shared-malloc-hugepage");
-  const bool use_huge_page = huge_page_mount_point[0] != '\0';
-#ifndef MAP_HUGETLB
-    xbt_assert(!use_huge_page, "Huge pages are not available on your system.");
+  bool use_huge_page = huge_page_mount_point[0] != '\0';
+#ifndef MAP_HUGETLB /* If the system header don't define that mmap flag */
+    xbt_assert(!use_huge_page, "Huge pages are not available on your system, you cannot use the smpi/shared-malloc-hugepage option.");
+    use_huge_page = 0;
 #endif
   smpi_shared_malloc_blocksize = static_cast<unsigned long>(xbt_cfg_get_double("smpi/shared-malloc-blocksize"));
   void *mem, *allocated_ptr;
   size_t allocated_size;
-#ifdef MAP_HUGETLB
   if(use_huge_page) {
     xbt_assert(smpi_shared_malloc_blocksize == HUGE_PAGE_SIZE, "the block size of shared malloc should be equal to the size of a huge page.");
     allocated_size = size + 2*smpi_shared_malloc_blocksize;
@@ -240,10 +240,6 @@ void* smpi_shared_malloc_partial(size_t size, size_t* shared_block_offsets, int 
     xbt_assert(smpi_shared_malloc_blocksize % PAGE_SIZE == 0, "the block size of shared malloc should be a multiple of the page size.");
     allocated_size = size;
   }
-#else
-  xbt_assert(smpi_shared_malloc_blocksize % PAGE_SIZE == 0, "the block size of shared malloc should be a multiple of the page size.");
-  allocated_size = size;
-#endif
 
 
   /* First reserve memory area */
@@ -253,20 +249,15 @@ void* smpi_shared_malloc_partial(size_t size, size_t* shared_block_offsets, int 
   xbt_assert(allocated_ptr != MAP_FAILED, "Failed to allocate %zuMiB of memory. Run \"sysctl vm.overcommit_memory=1\" as root "
                                 "to allow big allocations.\n",
              size >> 20);
-#ifdef MAP_HUGETLB
   if(use_huge_page)
     mem = (void*)ALIGN_UP((uint64_t)allocated_ptr, HUGE_PAGE_SIZE);
   else
     mem = allocated_ptr;
-#else
-  mem = allocated_ptr;
-#endif
 
   XBT_DEBUG("global shared allocation. Blocksize %lu", smpi_shared_malloc_blocksize);
   /* Create a fd to a new file on disk, make it smpi_shared_malloc_blocksize big, and unlink it.
    * It still exists in memory but not in the file system (thus it cannot be leaked). */
   /* Create bogus file if not done already */
-#ifdef MAP_HUGETLB
   if(use_huge_page && smpi_shared_malloc_bogusfile_huge_page == -1) {
     const char *const array[] = {huge_page_mount_point, "simgrid-shmalloc-XXXXXX", nullptr};
     char *huge_page_filename = xbt_str_join_array(array, "/");
@@ -275,7 +266,6 @@ void* smpi_shared_malloc_partial(size_t size, size_t* shared_block_offsets, int 
     unlink(huge_page_filename);
     xbt_free(huge_page_filename);
   }
-#endif
   if(smpi_shared_malloc_bogusfile == -1) {
     char *name                   = xbt_strdup("/tmp/simgrid-shmalloc-XXXXXX");
     smpi_shared_malloc_bogusfile = mkstemp(name);

--- a/src/smpi/smpi_shared.cpp
+++ b/src/smpi/smpi_shared.cpp
@@ -257,7 +257,12 @@ void* smpi_shared_malloc_partial(size_t size, size_t* shared_block_offsets, int 
   XBT_DEBUG("global shared allocation. Blocksize %lu", smpi_shared_malloc_blocksize);
   /* Create a fd to a new file on disk, make it smpi_shared_malloc_blocksize big, and unlink it.
    * It still exists in memory but not in the file system (thus it cannot be leaked). */
-  /* Create bogus file if not done already */
+  /* Create bogus file if not done already
+   * We need two different bogusfiles:
+   *    smpi_shared_malloc_bogusfile_huge_page is used for calls to mmap *with* MAP_HUGETLB,
+   *    smpi_shared_malloc_bogusfile is used for calls to mmap *without* MAP_HUGETLB.
+   * We cannot use a same file for the two type of calls, since the first one needs to be
+   * opened in a hugetlbfs mount point whereas the second needs to be a "classical" file. */
   if(use_huge_page && smpi_shared_malloc_bogusfile_huge_page == -1) {
     const char *const array[] = {huge_page_mount_point, "simgrid-shmalloc-XXXXXX", nullptr};
     char *huge_page_filename = xbt_str_join_array(array, "/");

--- a/src/smpi/smpi_shared.cpp
+++ b/src/smpi/smpi_shared.cpp
@@ -256,7 +256,7 @@ void* smpi_shared_malloc_partial(size_t size, size_t* shared_block_offsets, int 
    * It still exists in memory but not in the file system (thus it cannot be leaked). */
   /* Create bogus file if not done already */
   if(use_huge_page && smpi_shared_malloc_bogusfile_huge_page == -1) {
-    char *array[] = {huge_page_mount_point, "simgrid-shmalloc-XXXXXX", nullptr};
+    const char *const array[] = {huge_page_mount_point, "simgrid-shmalloc-XXXXXX", nullptr};
     char *huge_page_filename = xbt_str_join_array(array, "/");
     smpi_shared_malloc_bogusfile_huge_page = mkstemp(huge_page_filename);
     XBT_DEBUG("bogusfile_huge_page: %s\n", huge_page_filename);
@@ -296,8 +296,7 @@ void* smpi_shared_malloc_partial(size_t size, size_t* shared_block_offsets, int 
               "stop_offset (%zu) should be lower than its successor start offset (%zu)", stop_offset, shared_block_offsets[2*i_block+2]);
     size_t start_block_offset = ALIGN_UP(start_offset, smpi_shared_malloc_blocksize);
     size_t stop_block_offset = ALIGN_DOWN(stop_offset, smpi_shared_malloc_blocksize);
-    unsigned int i;
-    for (int block_id=0, i = start_block_offset / smpi_shared_malloc_blocksize; i < stop_block_offset / smpi_shared_malloc_blocksize; block_id++, i++) {
+    for (unsigned block_id=0, i = start_block_offset / smpi_shared_malloc_blocksize; i < stop_block_offset / smpi_shared_malloc_blocksize; block_id++, i++) {
       XBT_DEBUG("\t\tglobal shared allocation, mmap block offset %d", block_id);
       void* pos = (void*)((unsigned long)mem + i * smpi_shared_malloc_blocksize);
       void* res = mmap(pos, smpi_shared_malloc_blocksize, PROT_READ | PROT_WRITE, mmap_flag,


### PR DESCRIPTION
This adds an option to `smpirun` asking to use huge pages for the calls to `SMPI_SHARED_MALLOC` and `SMPI_PARTIAL_SHARED_MALLOC`.

To use it:
```bash
mkdir /home/huge && sudo mount none /home/huge -t hugetlbfs -o rw,mode=0777
sudo sh -c "/bin/echo 1 > /proc/sys/vm/nr_hugepages"
smpirun --cfg=smpi/shared-malloc-hugepage:/home/huge --cfg=smpi/shared-malloc-blocksize:2097152 [...]
```

For very large allocations, the page table grows very large and the kernel takes a lot of time working on this table, stalling the simulation.
For instance, without huge pages, HPL with a matrix of size 6e5 has a page table of 5.5GB and the simulation drops below 40% of CPU utilization.
Using huge pages fix this. Of course this only shifts the problem further, but this is an easy fix.

Currently, the size of a huge page is hard coded to be 2 MB, as I did not find a standard way to get it. Maybe we could just ask the user to provide it?