### PR TITLE
Comm.waitAny(comms) is not returning the communication index 

### DIFF
--- a/src/bindings/java/org/simgrid/msg/Comm.java
+++ b/src/bindings/java/org/simgrid/msg/Comm.java
@@ -59,7 +59,7 @@ public class Comm {
 		waitAll(comms, -1.);
 	}
 	/** Wait any of the communications, and return the rank of the terminating comm */
-	public static native void waitAny(Comm[] comms) throws TransferFailureException, HostFailureException, TimeoutException;
+	public static native int waitAny(Comm[] comms) throws TransferFailureException, HostFailureException, TimeoutException;
 	/**
 	 * Returns the task associated with the communication.
 	 * if the communication isn't finished yet, will return null.


### PR DESCRIPTION
The java bindings docummentation for Comm.waitAny(comms) says "Wait any of the communications, and return the rank of the terminating comm " [1]
But the signature returns void.

In the attached patch I changed the return type to int in order to be able to implement an experiment I'm working on [2]

Cheers,
Kevin

[1] https://github.com/simgrid/simgrid/blob/master/src/bindings/java/org/simgrid/msg/Comm.java#L61-L62
[2] https://github.com/kovin/simgrid-playground/blob/2a065cf2b46ede983706559c0304cc2704ad2dc4/examples/java/app/scalability/Peer.java#L45-L46