### PR TITLE
Fix breakpoint option

### DIFF
--- a/src/simix/smx_global.cpp
+++ b/src/simix/smx_global.cpp
@@ -397,7 +397,7 @@ void SIMIX_run()
   do {
     XBT_DEBUG("New Schedule Round; size(queue)=%zu", simix_global->process_to_run.size());
 
-    if (simgrid::simix::breakpoint >= 0.0 && time >= simgrid::simix::breakpoint) {
+    if (simgrid::simix::breakpoint >= 0.0 && surf_get_clock() >= simgrid::simix::breakpoint) {
       XBT_DEBUG("Breakpoint reached (%g)", simgrid::simix::breakpoint.get());
       simgrid::simix::breakpoint = -1.0;
 #ifdef SIGTRAP


### PR DESCRIPTION
It was using relative time deltas instead of absolute time.