### PR TITLE
[examples] smpi replay on steroids

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -750,6 +750,31 @@ if(NOT "${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_HOME_DIRECTORY}")
   configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple/ti_traces_32_1/ti_trace30.txt ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple/ti_traces_32_1/ti_trace30.txt COPYONLY)
   configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple/ti_traces_32_1/ti_trace31.txt ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple/ti_traces_32_1/ti_trace31.txt COPYONLY)
 
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/compute_only.txt ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/compute_only.txt COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/compute_only/actions0.txt ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/compute_only/actions0.txt COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/compute_only/actions1.txt ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/compute_only/actions1.txt COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/empty.txt ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/empty.txt COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/empty/actions0.txt ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/empty/actions0.txt COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/empty/actions1.txt ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/empty/actions1.txt COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/mixed.txt ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/mixed.txt COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/mixed/actions0.txt ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/mixed/actions0.txt COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/mixed/actions1.txt ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/mixed/actions1.txt COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/workload_compute ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_compute COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/workload_compute_consecutive ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_compute_consecutive COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/workload_compute_consecutive2 ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_compute_consecutive2 COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/workload_compute_simple ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_compute_simple COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/workload_empty1 ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_empty1 COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/workload_empty2 ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_empty2 COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/workload_empty2_same_resources ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_empty2_same_resources COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/workload_empty2_same_time ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_empty2_same_time COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/workload_empty2_same_time_and_resources ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_empty2_same_time_and_resources COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/workload_mixed1 ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_mixed1 COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/workload_mixed2 ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_mixed2 COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/workload_mixed2_same_resources ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_mixed2_same_resources COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/workload_mixed2_same_time ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_mixed2_same_time COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/workload_mixed2_same_time_and_resources ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_mixed2_same_time_and_resources COPYONLY)
+configure_file(${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy/workload_nojob ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_nojob COPYONLY)
+
   set(generated_files_to_clean
     ${generated_files_to_clean}
     ${CMAKE_BINARY_DIR}/examples/smpi/replay/actions0.txt
@@ -800,6 +825,31 @@ if(NOT "${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_HOME_DIRECTORY}")
     ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple/ti_traces_32_1/ti_trace29.txt
     ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple/ti_traces_32_1/ti_trace30.txt
     ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple/ti_traces_32_1/ti_trace31.txt
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/compute_only.txt
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/compute_only/actions0.txt
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/compute_only/actions1.txt
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/empty.txt
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/empty/actions0.txt
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/empty/actions1.txt
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/mixed.txt
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/mixed/actions0.txt
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/mixed/actions1.txt
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual.tesh
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_compute
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_compute_consecutive
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_compute_consecutive2
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_compute_simple
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_empty1
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_empty2
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_empty2_same_resources
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_empty2_same_time
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_empty2_same_time_and_resources
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_mixed1
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_mixed2
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_mixed2_same_resources
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_mixed2_same_time
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_mixed2_same_time_and_resources
+    ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy/workload_nojob
     )
 endif()
 

--- a/examples/smpi/replay_multiple_manual_deploy/CMakeLists.txt
+++ b/examples/smpi/replay_multiple_manual_deploy/CMakeLists.txt
@@ -1,0 +1,98 @@
+if(enable_smpi)
+  include_directories(BEFORE "${CMAKE_HOME_DIRECTORY}/include/smpi")
+
+  # Boost regex dependency
+  find_package(Boost COMPONENTS regex filesystem REQUIRED)
+
+  add_executable       (replay_multiple_manual replay_multiple_manual.cpp)
+  target_link_libraries(replay_multiple_manual simgrid ${Boost_LIBRARIES})
+
+  # Define a list of a tesh files
+  list(APPEND tesh_filename_list replay_multiple_manual_nojob)
+  list(APPEND tesh_filename_list replay_multiple_manual_nojob_noise)
+  list(APPEND tesh_filename_list replay_multiple_manual_empty1)
+  list(APPEND tesh_filename_list replay_multiple_manual_empty1_noise)
+  list(APPEND tesh_filename_list replay_multiple_manual_empty2)
+  list(APPEND tesh_filename_list replay_multiple_manual_empty2_noise)
+  list(APPEND tesh_filename_list replay_multiple_manual_empty2_sr)
+  list(APPEND tesh_filename_list replay_multiple_manual_empty2_sr_noise)
+  list(APPEND tesh_filename_list replay_multiple_manual_empty2_st)
+  list(APPEND tesh_filename_list replay_multiple_manual_empty2_st_noise)
+  list(APPEND tesh_filename_list replay_multiple_manual_empty2_st_sr)
+  list(APPEND tesh_filename_list replay_multiple_manual_empty2_st_sr_noise)
+  list(APPEND tesh_filename_list replay_multiple_manual_mixed1)
+  list(APPEND tesh_filename_list replay_multiple_manual_mixed1_noise)
+  list(APPEND tesh_filename_list replay_multiple_manual_mixed2)
+  list(APPEND tesh_filename_list replay_multiple_manual_mixed2_noise)
+  list(APPEND tesh_filename_list replay_multiple_manual_mixed2_sr)
+  list(APPEND tesh_filename_list replay_multiple_manual_mixed2_sr_noise)
+  list(APPEND tesh_filename_list replay_multiple_manual_mixed2_st)
+  list(APPEND tesh_filename_list replay_multiple_manual_mixed2_st_noise)
+  list(APPEND tesh_filename_list replay_multiple_manual_mixed2_st_sr)
+  list(APPEND tesh_filename_list replay_multiple_manual_mixed2_st_sr_noise)
+
+  # One-string version of the files (very ugly. Could be "just ugly" with recent CMake)
+  set(rm_tesh_files_as_string
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_nojob.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_nojob_noise.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_empty1.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_empty1_noise.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_empty2.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_empty2_noise.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_empty2_sr.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_empty2_sr_noise.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_empty2_st.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_empty2_st_noise.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_empty2_st_sr.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_empty2_st_sr_noise.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_mixed1.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_mixed1_noise.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_mixed2.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_mixed2_noise.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_mixed2_sr.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_mixed2_sr_noise.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_mixed2_st.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_mixed2_st_noise.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_mixed2_st_sr.tesh
+    ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual_mixed2_st_sr_noise.tesh
+  )
+
+  IF(NOT HAVE_MC)
+    foreach(rm_tesh_file IN LISTS tesh_filename_list)
+      string(REPLACE "_" "-" dash_separated ${rm_tesh_file})
+      ADD_TESH("smpi-${dash_separated}"
+        --setenv srcdir=${CMAKE_HOME_DIRECTORY}/examples/smpi/replay_multiple_manual_deploy
+        --cd ${CMAKE_BINARY_DIR}/examples/smpi/replay_multiple_manual_deploy
+        ${CMAKE_CURRENT_SOURCE_DIR}/${rm_tesh_file}.tesh)
+    endforeach()
+  ENDIF()
+endif()
+
+set(txt_files     ${txt_files}     ${CMAKE_CURRENT_SOURCE_DIR}/generate_multiple_deployment.sh
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/compute_only.txt
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/compute_only/actions0.txt
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/compute_only/actions1.txt
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/empty.txt
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/empty/actions0.txt
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/empty/actions1.txt
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/mixed.txt
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/mixed/actions0.txt
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/mixed/actions1.txt
+                                   ${rm_tesh_files_as_string}
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/workload_compute
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/workload_compute_consecutive
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/workload_compute_consecutive2
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/workload_compute_simple
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/workload_empty1
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/workload_empty2
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/workload_empty2_same_resources
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/workload_empty2_same_time
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/workload_empty2_same_time_and_resources
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/workload_mixed1
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/workload_mixed2
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/workload_mixed2_same_resources
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/workload_mixed2_same_time
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/workload_mixed2_same_time_and_resources
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/workload_nojob PARENT_SCOPE)
+set(tesh_files    ${tesh_files}    ${rm_tesh_files_as_string} PARENT_SCOPE)
+set(examples_src  ${examples_src}  ${CMAKE_CURRENT_SOURCE_DIR}/replay_multiple_manual.cpp PARENT_SCOPE)

--- a/examples/smpi/replay_multiple_manual_deploy/compute_only.txt
+++ b/examples/smpi/replay_multiple_manual_deploy/compute_only.txt
@@ -1,0 +1,2 @@
+compute_only/actions0.txt
+compute_only/actions1.txt

--- a/examples/smpi/replay_multiple_manual_deploy/compute_only/actions0.txt
+++ b/examples/smpi/replay_multiple_manual_deploy/compute_only/actions0.txt
@@ -1,0 +1,3 @@
+0 init
+0 compute 1e10
+0 finalize

--- a/examples/smpi/replay_multiple_manual_deploy/compute_only/actions1.txt
+++ b/examples/smpi/replay_multiple_manual_deploy/compute_only/actions1.txt
@@ -1,0 +1,3 @@
+1 init
+1 compute 1e10
+1 finalize

--- a/examples/smpi/replay_multiple_manual_deploy/empty.txt
+++ b/examples/smpi/replay_multiple_manual_deploy/empty.txt
@@ -1,0 +1,2 @@
+empty/actions0.txt
+empty/actions1.txt

--- a/examples/smpi/replay_multiple_manual_deploy/empty/actions0.txt
+++ b/examples/smpi/replay_multiple_manual_deploy/empty/actions0.txt
@@ -1,0 +1,2 @@
+0 init
+0 finalize

--- a/examples/smpi/replay_multiple_manual_deploy/empty/actions1.txt
+++ b/examples/smpi/replay_multiple_manual_deploy/empty/actions1.txt
@@ -1,0 +1,2 @@
+1 init
+1 finalize

--- a/examples/smpi/replay_multiple_manual_deploy/mixed.txt
+++ b/examples/smpi/replay_multiple_manual_deploy/mixed.txt
@@ -1,0 +1,2 @@
+mixed/actions0.txt
+mixed/actions1.txt

--- a/examples/smpi/replay_multiple_manual_deploy/mixed/actions0.txt
+++ b/examples/smpi/replay_multiple_manual_deploy/mixed/actions0.txt
@@ -1,0 +1,7 @@
+0 init
+0 send 1 0 1e9
+0 recv 1 0 1e9
+0 compute 1e10
+0 send 1 0 1e9
+0 recv 1 0 1e9
+0 finalize

--- a/examples/smpi/replay_multiple_manual_deploy/mixed/actions1.txt
+++ b/examples/smpi/replay_multiple_manual_deploy/mixed/actions1.txt
@@ -1,0 +1,7 @@
+1 init
+1 recv 0 0 1e9
+1 send 0 0 1e9
+1 compute 1e10
+1 recv 0 0 1e9
+1 send 0 0 1e9
+1 finalize

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual.cpp
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual.cpp
@@ -1,0 +1,298 @@
+/* Copyright (c) 2009-2018. The SimGrid Team.
+ * All rights reserved.                                                     */
+
+/* This program is free software; you can redistribute it and/or modify it
+ * under the terms of the license (GNU LGPL) which comes with this package. */
+
+/* This example shows how to replay SMPI time-independent traces in a dynamic
+   fashion. It is inspired from Batsim (https://github.com/oar-team/batsim).
+
+   The program workflow can be summarized as:
+   1. Read an input workload (set of jobs).
+      Each job is a time-independent trace and a starting time.
+   2. Create initial noise, by spawning useless actors.
+      This is done to avoid SMPI actors to start at actor_id=0.
+   3. For each job:
+        1. Sleep until job's starting time is reached (if needed)
+        2. Launch the replay of the corresponding time-indepent trace.
+        3. Create inter-process noise, by spawning useless actors.
+   4. Wait for completion (implicitly, via MSG_main's return)
+*/
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/regex.hpp>
+
+#include <simgrid/msg.h>
+#include <simgrid/s4u.hpp>
+#include <smpi/smpi.h>
+
+XBT_LOG_NEW_DEFAULT_CATEGORY(replay_multiple_manual, "Messages specific for this example");
+
+struct Job {
+  std::string smpi_app_name;   //!< The unique name of the SMPI application
+  std::string filename;        //!<  The filename of the main trace file (which contains other filenames for each rank)
+  int app_size;                //!< The number of processes (actors) of the job
+  int starting_time;           //!< When the job should start
+  std::vector<int> allocation; //!< Where the job should be executed. Values are hosts indexes.
+  std::vector<std::string> traces_filenames; //!< The filenames of the different action files. Read from filename.
+  int unique_job_number;                     //!< The job unique number in [0, n[.
+};
+
+// ugly globals to avoid creating structures for giving args to processes
+std::vector<simgrid::s4u::Host*> hosts;
+int noise_between_jobs;
+
+static bool job_comparator(const Job* j1, const Job* j2)
+{
+  if (j1->starting_time == j2->starting_time)
+    return j1->smpi_app_name < j2->smpi_app_name;
+  return j1->starting_time < j2->starting_time;
+}
+
+struct s_smpi_replay_process_args {
+  Job* job;
+  msg_sem_t semaphore;
+  int rank;
+};
+
+static int smpi_replay_process(int argc, char* argv[])
+{
+  s_smpi_replay_process_args* args = static_cast<s_smpi_replay_process_args*>(MSG_process_get_data(MSG_process_self()));
+
+  if (args->semaphore != nullptr)
+    MSG_sem_acquire(args->semaphore);
+
+  XBT_INFO("Replaying rank %d of job %d (smpi_app '%s')", args->rank, args->job->unique_job_number,
+           args->job->smpi_app_name.c_str());
+
+  smpi_replay_run(&argc, &argv);
+  XBT_INFO("Finished replaying rank %d of job %d (smpi_app '%s')", args->rank, args->job->unique_job_number,
+           args->job->smpi_app_name.c_str());
+
+  if (args->semaphore != nullptr)
+    MSG_sem_release(args->semaphore);
+
+  delete args;
+  return 0;
+}
+
+// Sleeps for a given amount of time
+static int sleeper_process(int* param)
+{
+  XBT_DEBUG("Sleeping for %d seconds", *param);
+  simgrid::s4u::this_actor::sleep_for(*param);
+
+  delete param;
+
+  return 0;
+}
+
+// Launches some sleeper processes
+static void pop_some_processes(int nb_processes, simgrid::s4u::Host* host)
+{
+  for (int i = 0; i < nb_processes; ++i) {
+    int* param = new int;
+    *param     = i + 1;
+    simgrid::s4u::Actor::create("meh", host, sleeper_process, param);
+  }
+}
+
+static int job_executor_process(Job* job)
+{
+  msg_sem_t job_semaphore = MSG_sem_init(1);
+  XBT_INFO("Executing job %d (smpi_app '%s')", job->unique_job_number, job->smpi_app_name.c_str());
+
+  for (int i = 0; i < job->app_size; ++i) {
+    char *str_instance_name, *str_rank, *str_pname, *str_tfname;
+    int err = asprintf(&str_instance_name, "%s", job->smpi_app_name.c_str());
+    xbt_assert(err != -1, "asprintf error");
+    err = asprintf(&str_rank, "%d", i);
+    xbt_assert(err != -1, "asprintf error");
+    err = asprintf(&str_pname, "%d_%d", job->unique_job_number, i);
+    xbt_assert(err != -1, "asprintf error");
+    err = asprintf(&str_tfname, "%s", job->traces_filenames[i].c_str());
+    xbt_assert(err != -1, "asprintf error");
+
+    char** argv = xbt_new(char*, 5);
+    argv[0]     = xbt_strdup("1");   // log only?
+    argv[1]     = str_instance_name; // application instance
+    argv[2]     = str_rank;          // rank
+    argv[3]     = str_tfname;        // smpi trace file for this rank
+    argv[4]     = xbt_strdup("0");   // ?
+
+    s_smpi_replay_process_args* args = new s_smpi_replay_process_args;
+    args->job                        = job;
+    args->semaphore                  = nullptr;
+    args->rank                       = i;
+
+    if (i == 0)
+      args->semaphore = job_semaphore;
+
+    MSG_process_create_with_arguments(str_pname, smpi_replay_process, (void*)args, hosts[job->allocation[i]], 5, argv);
+    free(str_pname);
+  }
+
+  MSG_sem_acquire(job_semaphore);
+  MSG_sem_destroy(job_semaphore);
+
+  XBT_INFO("Finished job %d (smpi_app '%s')", job->unique_job_number, job->smpi_app_name.c_str());
+
+  return 0;
+}
+
+// Executes a workload of SMPI processes
+static int workload_executor_process(std::vector<Job*>* workload)
+{
+  for (Job* job : *workload) {
+    // Let's wait until the job's waiting time if needed
+    double curr_time = simgrid::s4u::Engine::get_clock();
+    if (job->starting_time > curr_time) {
+      double time_to_sleep = (double)job->starting_time - curr_time;
+      XBT_INFO("Sleeping %g seconds (waiting for job %d, app '%s')", time_to_sleep, job->starting_time,
+               job->smpi_app_name.c_str());
+      simgrid::s4u::this_actor::sleep_for(time_to_sleep);
+    }
+
+    if (noise_between_jobs > 0) {
+      // Let's add some process noise
+      XBT_DEBUG("Popping %d noise processes before running job %d (app '%s')", noise_between_jobs,
+                job->unique_job_number, job->smpi_app_name.c_str());
+      pop_some_processes(noise_between_jobs, hosts[job->allocation[0]]);
+    }
+
+    // Let's finally run the job executor
+    std::string job_process_name = "job_" + job->smpi_app_name;
+    XBT_INFO("Launching the job executor of job %d (app '%s')", job->unique_job_number, job->smpi_app_name.c_str());
+    simgrid::s4u::Actor::create(job_process_name.c_str(), hosts[job->allocation[0]], job_executor_process, job);
+  }
+
+  return 0;
+}
+
+// Reads jobs from a workload file and returns them
+static std::vector<Job*> all_jobs(const std::string& workload_file)
+{
+  std::ifstream f(workload_file);
+  xbt_assert(f.is_open(), "Cannot open file '%s'.", workload_file.c_str());
+  std::vector<Job*> jobs;
+
+  boost::filesystem::path path(workload_file);
+  std::string dir = path.parent_path().native();
+
+  boost::regex r(R"(^\s*(\S+)\s+(\S+\.txt)\s+(\d+)\s+(\d+)\s+(\d+(?:,\d+)*).*$)");
+  std::string line;
+  while (std::getline(f, line)) {
+    boost::smatch m;
+
+    if (boost::regex_match(line, m, r)) {
+      try {
+        Job* job           = new Job;
+        job->smpi_app_name = m[1];
+        job->filename      = dir + "/" + std::string(m[2]);
+        job->app_size      = stoi(m[3]);
+        job->starting_time = stoi(m[4]);
+        std::string alloc  = m[5];
+
+        std::string filename_unprefixed = m[2];
+
+        std::vector<std::string> subparts;
+        boost::split(subparts, alloc, boost::is_any_of(","), boost::token_compress_on);
+
+        if ((int)subparts.size() != job->app_size)
+          throw std::runtime_error("size/alloc inconsistency");
+
+        job->allocation.resize(subparts.size());
+        for (unsigned int i = 0; i < subparts.size(); ++i)
+          job->allocation[i] = stoi(subparts[i]);
+
+        // Let's read the filename
+        std::ifstream traces_file(job->filename);
+        if (!traces_file.is_open())
+          throw std::runtime_error("Cannot open file " + job->filename);
+
+        std::string traces_line;
+        while (std::getline(traces_file, traces_line)) {
+          boost::trim_right(traces_line);
+          job->traces_filenames.push_back(dir + "/" + traces_line);
+        }
+
+        if (static_cast<int>(job->traces_filenames.size()) < job->app_size)
+          throw std::runtime_error("size/tracefiles inconsistency");
+        job->traces_filenames.resize(job->app_size);
+
+        XBT_INFO("Job read: app='%s', file='%s', size=%d, start=%d, "
+                 "alloc='%s'",
+                 job->smpi_app_name.c_str(), filename_unprefixed.c_str(), job->app_size, job->starting_time,
+                 alloc.c_str());
+        jobs.push_back(job);
+      } catch (const std::exception& e) {
+        printf("Bad line '%s' of file '%s': %s.\n", line.c_str(), workload_file.c_str(), e.what());
+      }
+    }
+  }
+
+  // Jobs are sorted by ascending date, then by lexicographical order of their
+  // application names
+  sort(jobs.begin(), jobs.end(), job_comparator);
+
+  for (unsigned int i = 0; i < jobs.size(); ++i)
+    jobs[i]->unique_job_number = i;
+
+  return jobs;
+}
+
+int main(int argc, char* argv[])
+{
+  xbt_assert(argc > 4,
+             "Usage: %s platform_file workload_file initial_noise noise_between_jobs\n"
+             "\tExample: %s platform.xml workload_compute\n",
+             argv[0], argv[0]);
+
+  //  Simulation setting
+  MSG_init(&argc, argv);
+  simgrid::s4u::Engine e(&argc, argv);
+  e.load_platform(argv[1]);
+  hosts = e.get_all_hosts();
+  xbt_assert(hosts.size() >= 4, "The given platform should contain at least 4 hosts (found %zu).", hosts.size());
+
+  // Let's retrieve all SMPI jobs
+  std::vector<Job*> jobs = all_jobs(argv[2]);
+
+  // Let's register them
+  for (const Job* job : jobs)
+    SMPI_app_instance_register(job->smpi_app_name.c_str(), smpi_replay_process, job->app_size);
+
+  SMPI_init();
+
+  // Read noise arguments
+  int initial_noise = std::stoi(argv[3]);
+  xbt_assert(initial_noise >= 0, "Invalid initial_noise argument");
+
+  noise_between_jobs = std::stoi(argv[4]);
+  xbt_assert(noise_between_jobs >= 0, "Invalid noise_between_jobs argument");
+
+  if (initial_noise > 0) {
+    XBT_DEBUG("Popping %d noise processes", initial_noise);
+    pop_some_processes(initial_noise, hosts[0]);
+  }
+
+  // Let's execute the workload
+  simgrid::s4u::Actor::create("workload_executor", hosts[0], workload_executor_process, &jobs);
+
+  e.run();
+  XBT_INFO("Simulation finished! Final time: %g", e.get_clock());
+
+  SMPI_finalize();
+
+  for (const Job* job : jobs)
+    delete job;
+
+  return 0;
+}

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty1.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty1.tesh
@@ -1,0 +1,16 @@
+p Workload with one empty job
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml  ${srcdir:=.}/workload_empty1 --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 0 0
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='alone', file='empty.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'alone')
+> [   0.000000] (job_alone@Bourassa) Executing job 0 (smpi_app 'alone')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'alone')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'alone')
+> [   0.000000] (0_0@Bourassa) Simulation time 0.000000
+> [   0.000000] (0_1@Fafard) Simulation time 0.000000
+> [   0.000000] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'alone')
+> [   0.000000] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'alone')
+> [   0.000000] (job_alone@Bourassa) Finished job 0 (smpi_app 'alone')
+> [   0.000000] (maestro@) Simulation finished! Final time: 0

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty1_noise.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty1_noise.tesh
@@ -1,0 +1,16 @@
+p Workload with one empty job
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml  ${srcdir:=.}/workload_empty1 --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 7 13
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='alone', file='empty.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'alone')
+> [   0.000000] (job_alone@Bourassa) Executing job 0 (smpi_app 'alone')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'alone')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'alone')
+> [   0.000000] (0_0@Bourassa) Simulation time 0.000000
+> [   0.000000] (0_1@Fafard) Simulation time 0.000000
+> [   0.000000] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'alone')
+> [   0.000000] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'alone')
+> [   0.000000] (job_alone@Bourassa) Finished job 0 (smpi_app 'alone')
+> [  13.000000] (maestro@) Simulation finished! Final time: 13

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty2.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty2.tesh
@@ -1,0 +1,28 @@
+# comment
+p Workload with two empty jobs (not at the same time, not on the same resources)
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml ${srcdir:=.}/workload_empty2 --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 0 0
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='job0', file='empty.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (maestro@) Job read: app='job1', file='empty.txt', size=2, start=1000, alloc='2,3'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'job0')
+> [   0.000000] (job_job0@Bourassa) Executing job 0 (smpi_app 'job0')
+> [   0.000000] (workload_executor@Bourassa) Sleeping 1000 seconds (waiting for job 1000, app 'job1')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (0_0@Bourassa) Simulation time 0.000000
+> [   0.000000] (0_1@Fafard) Simulation time 0.000000
+> [   0.000000] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (job_job0@Bourassa) Finished job 0 (smpi_app 'job0')
+> [1000.000000] (workload_executor@Bourassa) Launching the job executor of job 1 (app 'job1')
+> [1000.000000] (job_job1@Ginette) Executing job 1 (smpi_app 'job1')
+> [1000.000000] (1_0@Ginette) Replaying rank 0 of job 1 (smpi_app 'job1')
+> [1000.000000] (1_1@Jupiter) Replaying rank 1 of job 1 (smpi_app 'job1')
+> [1000.000000] (1_0@Ginette) Simulation time 0.000000
+> [1000.000000] (1_1@Jupiter) Simulation time 0.000000
+> [1000.000000] (1_1@Jupiter) Finished replaying rank 1 of job 1 (smpi_app 'job1')
+> [1000.000000] (1_0@Ginette) Finished replaying rank 0 of job 1 (smpi_app 'job1')
+> [1000.000000] (job_job1@Ginette) Finished job 1 (smpi_app 'job1')
+> [1000.000000] (maestro@) Simulation finished! Final time: 1000

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty2_noise.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty2_noise.tesh
@@ -1,0 +1,28 @@
+# comment
+p Workload with two empty jobs (not at the same time, not on the same resources)
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml ${srcdir:=.}/workload_empty2 --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 7 13
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='job0', file='empty.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (maestro@) Job read: app='job1', file='empty.txt', size=2, start=1000, alloc='2,3'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'job0')
+> [   0.000000] (job_job0@Bourassa) Executing job 0 (smpi_app 'job0')
+> [   0.000000] (workload_executor@Bourassa) Sleeping 1000 seconds (waiting for job 1000, app 'job1')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (0_0@Bourassa) Simulation time 0.000000
+> [   0.000000] (0_1@Fafard) Simulation time 0.000000
+> [   0.000000] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (job_job0@Bourassa) Finished job 0 (smpi_app 'job0')
+> [1000.000000] (workload_executor@Bourassa) Launching the job executor of job 1 (app 'job1')
+> [1000.000000] (job_job1@Ginette) Executing job 1 (smpi_app 'job1')
+> [1000.000000] (1_0@Ginette) Replaying rank 0 of job 1 (smpi_app 'job1')
+> [1000.000000] (1_1@Jupiter) Replaying rank 1 of job 1 (smpi_app 'job1')
+> [1000.000000] (1_0@Ginette) Simulation time 0.000000
+> [1000.000000] (1_1@Jupiter) Simulation time 0.000000
+> [1000.000000] (1_1@Jupiter) Finished replaying rank 1 of job 1 (smpi_app 'job1')
+> [1000.000000] (1_0@Ginette) Finished replaying rank 0 of job 1 (smpi_app 'job1')
+> [1000.000000] (job_job1@Ginette) Finished job 1 (smpi_app 'job1')
+> [1013.000000] (maestro@) Simulation finished! Final time: 1013

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty2_sr.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty2_sr.tesh
@@ -1,0 +1,27 @@
+p Workload with two empty jobs (not at the same time, but on the same resources)
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml ${srcdir:=.}/workload_empty2_same_resources --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 0 0
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='job0', file='empty.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (maestro@) Job read: app='job1', file='empty.txt', size=2, start=1000, alloc='0,1'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'job0')
+> [   0.000000] (job_job0@Bourassa) Executing job 0 (smpi_app 'job0')
+> [   0.000000] (workload_executor@Bourassa) Sleeping 1000 seconds (waiting for job 1000, app 'job1')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (0_0@Bourassa) Simulation time 0.000000
+> [   0.000000] (0_1@Fafard) Simulation time 0.000000
+> [   0.000000] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (job_job0@Bourassa) Finished job 0 (smpi_app 'job0')
+> [1000.000000] (workload_executor@Bourassa) Launching the job executor of job 1 (app 'job1')
+> [1000.000000] (job_job1@Bourassa) Executing job 1 (smpi_app 'job1')
+> [1000.000000] (1_0@Bourassa) Replaying rank 0 of job 1 (smpi_app 'job1')
+> [1000.000000] (1_1@Fafard) Replaying rank 1 of job 1 (smpi_app 'job1')
+> [1000.000000] (1_0@Bourassa) Simulation time 0.000000
+> [1000.000000] (1_1@Fafard) Simulation time 0.000000
+> [1000.000000] (1_1@Fafard) Finished replaying rank 1 of job 1 (smpi_app 'job1')
+> [1000.000000] (1_0@Bourassa) Finished replaying rank 0 of job 1 (smpi_app 'job1')
+> [1000.000000] (job_job1@Bourassa) Finished job 1 (smpi_app 'job1')
+> [1000.000000] (maestro@) Simulation finished! Final time: 1000

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty2_sr_noise.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty2_sr_noise.tesh
@@ -1,0 +1,27 @@
+p Workload with two empty jobs (not at the same time, but on the same resources)
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml ${srcdir:=.}/workload_empty2_same_resources --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 7 13
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='job0', file='empty.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (maestro@) Job read: app='job1', file='empty.txt', size=2, start=1000, alloc='0,1'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'job0')
+> [   0.000000] (job_job0@Bourassa) Executing job 0 (smpi_app 'job0')
+> [   0.000000] (workload_executor@Bourassa) Sleeping 1000 seconds (waiting for job 1000, app 'job1')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (0_0@Bourassa) Simulation time 0.000000
+> [   0.000000] (0_1@Fafard) Simulation time 0.000000
+> [   0.000000] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (job_job0@Bourassa) Finished job 0 (smpi_app 'job0')
+> [1000.000000] (workload_executor@Bourassa) Launching the job executor of job 1 (app 'job1')
+> [1000.000000] (job_job1@Bourassa) Executing job 1 (smpi_app 'job1')
+> [1000.000000] (1_0@Bourassa) Replaying rank 0 of job 1 (smpi_app 'job1')
+> [1000.000000] (1_1@Fafard) Replaying rank 1 of job 1 (smpi_app 'job1')
+> [1000.000000] (1_0@Bourassa) Simulation time 0.000000
+> [1000.000000] (1_1@Fafard) Simulation time 0.000000
+> [1000.000000] (1_1@Fafard) Finished replaying rank 1 of job 1 (smpi_app 'job1')
+> [1000.000000] (1_0@Bourassa) Finished replaying rank 0 of job 1 (smpi_app 'job1')
+> [1000.000000] (job_job1@Bourassa) Finished job 1 (smpi_app 'job1')
+> [1013.000000] (maestro@) Simulation finished! Final time: 1013

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty2_st.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty2_st.tesh
@@ -1,0 +1,26 @@
+p Workload with two empty jobs (at the same time but not on the same resources)
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml ${srcdir:=.}/workload_empty2_same_time --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 0 0
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='job0', file='empty.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (maestro@) Job read: app='job1', file='empty.txt', size=2, start=0, alloc='2,3'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'job0')
+> [   0.000000] (job_job0@Bourassa) Executing job 0 (smpi_app 'job0')
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 1 (app 'job1')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (job_job1@Ginette) Executing job 1 (smpi_app 'job1')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (1_0@Ginette) Replaying rank 0 of job 1 (smpi_app 'job1')
+> [   0.000000] (1_1@Jupiter) Replaying rank 1 of job 1 (smpi_app 'job1')
+> [   0.000000] (0_0@Bourassa) Simulation time 0.000000
+> [   0.000000] (0_1@Fafard) Simulation time 0.000000
+> [   0.000000] (1_0@Ginette) Simulation time 0.000000
+> [   0.000000] (1_1@Jupiter) Simulation time 0.000000
+> [   0.000000] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (1_1@Jupiter) Finished replaying rank 1 of job 1 (smpi_app 'job1')
+> [   0.000000] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (1_0@Ginette) Finished replaying rank 0 of job 1 (smpi_app 'job1')
+> [   0.000000] (job_job0@Bourassa) Finished job 0 (smpi_app 'job0')
+> [   0.000000] (job_job1@Ginette) Finished job 1 (smpi_app 'job1')
+> [   0.000000] (maestro@) Simulation finished! Final time: 0

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty2_st_noise.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty2_st_noise.tesh
@@ -1,0 +1,26 @@
+p Workload with two empty jobs (at the same time but not on the same resources)
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml ${srcdir:=.}/workload_empty2_same_time --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 7 13
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='job0', file='empty.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (maestro@) Job read: app='job1', file='empty.txt', size=2, start=0, alloc='2,3'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'job0')
+> [   0.000000] (job_job0@Bourassa) Executing job 0 (smpi_app 'job0')
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 1 (app 'job1')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (job_job1@Ginette) Executing job 1 (smpi_app 'job1')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (1_0@Ginette) Replaying rank 0 of job 1 (smpi_app 'job1')
+> [   0.000000] (1_1@Jupiter) Replaying rank 1 of job 1 (smpi_app 'job1')
+> [   0.000000] (0_0@Bourassa) Simulation time 0.000000
+> [   0.000000] (0_1@Fafard) Simulation time 0.000000
+> [   0.000000] (1_0@Ginette) Simulation time 0.000000
+> [   0.000000] (1_1@Jupiter) Simulation time 0.000000
+> [   0.000000] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (1_1@Jupiter) Finished replaying rank 1 of job 1 (smpi_app 'job1')
+> [   0.000000] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (1_0@Ginette) Finished replaying rank 0 of job 1 (smpi_app 'job1')
+> [   0.000000] (job_job0@Bourassa) Finished job 0 (smpi_app 'job0')
+> [   0.000000] (job_job1@Ginette) Finished job 1 (smpi_app 'job1')
+> [  13.000000] (maestro@) Simulation finished! Final time: 13

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty2_st_sr.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty2_st_sr.tesh
@@ -1,0 +1,26 @@
+p Workload with two empty jobs (at the same time and on the same resources)
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml ${srcdir:=.}/workload_empty2_same_time_and_resources --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 0 0
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='job0', file='empty.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (maestro@) Job read: app='job1', file='empty.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'job0')
+> [   0.000000] (job_job0@Bourassa) Executing job 0 (smpi_app 'job0')
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 1 (app 'job1')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (job_job1@Bourassa) Executing job 1 (smpi_app 'job1')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (1_0@Bourassa) Replaying rank 0 of job 1 (smpi_app 'job1')
+> [   0.000000] (1_1@Fafard) Replaying rank 1 of job 1 (smpi_app 'job1')
+> [   0.000000] (1_0@Bourassa) Simulation time 0.000000
+> [   0.000000] (0_0@Bourassa) Simulation time 0.000000
+> [   0.000000] (1_1@Fafard) Simulation time 0.000000
+> [   0.000000] (0_1@Fafard) Simulation time 0.000000
+> [   0.000000] (1_1@Fafard) Finished replaying rank 1 of job 1 (smpi_app 'job1')
+> [   0.000000] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (1_0@Bourassa) Finished replaying rank 0 of job 1 (smpi_app 'job1')
+> [   0.000000] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (job_job1@Bourassa) Finished job 1 (smpi_app 'job1')
+> [   0.000000] (job_job0@Bourassa) Finished job 0 (smpi_app 'job0')
+> [   0.000000] (maestro@) Simulation finished! Final time: 0

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty2_st_sr_noise.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_empty2_st_sr_noise.tesh
@@ -1,0 +1,26 @@
+p Workload with two empty jobs (at the same time and on the same resources)
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml ${srcdir:=.}/workload_empty2_same_time_and_resources --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 7 13
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='job0', file='empty.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (maestro@) Job read: app='job1', file='empty.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'job0')
+> [   0.000000] (job_job0@Bourassa) Executing job 0 (smpi_app 'job0')
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 1 (app 'job1')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (job_job1@Bourassa) Executing job 1 (smpi_app 'job1')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (1_0@Bourassa) Replaying rank 0 of job 1 (smpi_app 'job1')
+> [   0.000000] (1_1@Fafard) Replaying rank 1 of job 1 (smpi_app 'job1')
+> [   0.000000] (1_0@Bourassa) Simulation time 0.000000
+> [   0.000000] (0_0@Bourassa) Simulation time 0.000000
+> [   0.000000] (1_1@Fafard) Simulation time 0.000000
+> [   0.000000] (0_1@Fafard) Simulation time 0.000000
+> [   0.000000] (1_1@Fafard) Finished replaying rank 1 of job 1 (smpi_app 'job1')
+> [   0.000000] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (1_0@Bourassa) Finished replaying rank 0 of job 1 (smpi_app 'job1')
+> [   0.000000] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (job_job1@Bourassa) Finished job 1 (smpi_app 'job1')
+> [   0.000000] (job_job0@Bourassa) Finished job 0 (smpi_app 'job0')
+> [  13.000000] (maestro@) Simulation finished! Final time: 13

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed1.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed1.tesh
@@ -1,0 +1,15 @@
+p Workload with one mixed job
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml  ${srcdir:=.}/workload_mixed1 --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 0 0
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='alone', file='mixed.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'alone')
+> [   0.000000] (job_alone@Bourassa) Executing job 0 (smpi_app 'alone')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'alone')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'alone')
+> [ 737.001374] (0_0@Bourassa) Simulation time 737.001374
+> [ 737.001374] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'alone')
+> [ 737.001374] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'alone')
+> [ 737.001374] (job_alone@Bourassa) Finished job 0 (smpi_app 'alone')
+> [ 737.001374] (maestro@) Simulation finished! Final time: 737.001

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed1_noise.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed1_noise.tesh
@@ -1,0 +1,15 @@
+p Workload with one mixed job
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml  ${srcdir:=.}/workload_mixed1 --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 7 13
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='alone', file='mixed.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'alone')
+> [   0.000000] (job_alone@Bourassa) Executing job 0 (smpi_app 'alone')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'alone')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'alone')
+> [ 737.001374] (0_0@Bourassa) Simulation time 737.001374
+> [ 737.001374] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'alone')
+> [ 737.001374] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'alone')
+> [ 737.001374] (job_alone@Bourassa) Finished job 0 (smpi_app 'alone')
+> [ 737.001374] (maestro@) Simulation finished! Final time: 737.001

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2.tesh
@@ -1,0 +1,26 @@
+# comment
+p Workload with two mixed jobs (not at the same time, not on the same resources)
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml ${srcdir:=.}/workload_mixed2 --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 0 0
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='job0', file='mixed.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (maestro@) Job read: app='job1', file='mixed.txt', size=2, start=1000, alloc='2,3'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'job0')
+> [   0.000000] (job_job0@Bourassa) Executing job 0 (smpi_app 'job0')
+> [   0.000000] (workload_executor@Bourassa) Sleeping 1000 seconds (waiting for job 1000, app 'job1')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'job0')
+> [ 737.001374] (0_0@Bourassa) Simulation time 737.001374
+> [ 737.001374] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
+> [ 737.001374] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
+> [ 737.001374] (job_job0@Bourassa) Finished job 0 (smpi_app 'job0')
+> [1000.000000] (workload_executor@Bourassa) Launching the job executor of job 1 (app 'job1')
+> [1000.000000] (job_job1@Ginette) Executing job 1 (smpi_app 'job1')
+> [1000.000000] (1_0@Ginette) Replaying rank 0 of job 1 (smpi_app 'job1')
+> [1000.000000] (1_1@Jupiter) Replaying rank 1 of job 1 (smpi_app 'job1')
+> [1806.923160] (1_0@Ginette) Simulation time 806.923160
+> [1806.923160] (1_0@Ginette) Finished replaying rank 0 of job 1 (smpi_app 'job1')
+> [1806.923160] (1_1@Jupiter) Finished replaying rank 1 of job 1 (smpi_app 'job1')
+> [1806.923160] (job_job1@Ginette) Finished job 1 (smpi_app 'job1')
+> [1806.923160] (maestro@) Simulation finished! Final time: 1806.92

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2_noise.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2_noise.tesh
@@ -1,0 +1,26 @@
+# comment
+p Workload with two mixed jobs (not at the same time, not on the same resources)
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml ${srcdir:=.}/workload_mixed2 --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 7 13
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='job0', file='mixed.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (maestro@) Job read: app='job1', file='mixed.txt', size=2, start=1000, alloc='2,3'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'job0')
+> [   0.000000] (job_job0@Bourassa) Executing job 0 (smpi_app 'job0')
+> [   0.000000] (workload_executor@Bourassa) Sleeping 1000 seconds (waiting for job 1000, app 'job1')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'job0')
+> [ 737.001374] (0_0@Bourassa) Simulation time 737.001374
+> [ 737.001374] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
+> [ 737.001374] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
+> [ 737.001374] (job_job0@Bourassa) Finished job 0 (smpi_app 'job0')
+> [1000.000000] (workload_executor@Bourassa) Launching the job executor of job 1 (app 'job1')
+> [1000.000000] (job_job1@Ginette) Executing job 1 (smpi_app 'job1')
+> [1000.000000] (1_0@Ginette) Replaying rank 0 of job 1 (smpi_app 'job1')
+> [1000.000000] (1_1@Jupiter) Replaying rank 1 of job 1 (smpi_app 'job1')
+> [1806.923160] (1_0@Ginette) Simulation time 806.923160
+> [1806.923160] (1_0@Ginette) Finished replaying rank 0 of job 1 (smpi_app 'job1')
+> [1806.923160] (1_1@Jupiter) Finished replaying rank 1 of job 1 (smpi_app 'job1')
+> [1806.923160] (job_job1@Ginette) Finished job 1 (smpi_app 'job1')
+> [1806.923160] (maestro@) Simulation finished! Final time: 1806.92

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2_sr.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2_sr.tesh
@@ -1,0 +1,25 @@
+p Workload with two mixed jobs (not at the same time, but on the same resources)
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml ${srcdir:=.}/workload_mixed2_same_resources --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 0 0
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='job0', file='mixed.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (maestro@) Job read: app='job1', file='mixed.txt', size=2, start=1000, alloc='0,1'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'job0')
+> [   0.000000] (job_job0@Bourassa) Executing job 0 (smpi_app 'job0')
+> [   0.000000] (workload_executor@Bourassa) Sleeping 1000 seconds (waiting for job 1000, app 'job1')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'job0')
+> [ 737.001374] (0_0@Bourassa) Simulation time 737.001374
+> [ 737.001374] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
+> [ 737.001374] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
+> [ 737.001374] (job_job0@Bourassa) Finished job 0 (smpi_app 'job0')
+> [1000.000000] (workload_executor@Bourassa) Launching the job executor of job 1 (app 'job1')
+> [1000.000000] (job_job1@Bourassa) Executing job 1 (smpi_app 'job1')
+> [1000.000000] (1_0@Bourassa) Replaying rank 0 of job 1 (smpi_app 'job1')
+> [1000.000000] (1_1@Fafard) Replaying rank 1 of job 1 (smpi_app 'job1')
+> [1737.001374] (1_0@Bourassa) Simulation time 737.001374
+> [1737.001374] (1_0@Bourassa) Finished replaying rank 0 of job 1 (smpi_app 'job1')
+> [1737.001374] (1_1@Fafard) Finished replaying rank 1 of job 1 (smpi_app 'job1')
+> [1737.001374] (job_job1@Bourassa) Finished job 1 (smpi_app 'job1')
+> [1737.001374] (maestro@) Simulation finished! Final time: 1737

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2_sr_noise.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2_sr_noise.tesh
@@ -1,0 +1,25 @@
+p Workload with two mixed jobs (not at the same time, but on the same resources)
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml ${srcdir:=.}/workload_mixed2_same_resources --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 7 13
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='job0', file='mixed.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (maestro@) Job read: app='job1', file='mixed.txt', size=2, start=1000, alloc='0,1'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'job0')
+> [   0.000000] (job_job0@Bourassa) Executing job 0 (smpi_app 'job0')
+> [   0.000000] (workload_executor@Bourassa) Sleeping 1000 seconds (waiting for job 1000, app 'job1')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'job0')
+> [ 737.001374] (0_0@Bourassa) Simulation time 737.001374
+> [ 737.001374] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
+> [ 737.001374] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
+> [ 737.001374] (job_job0@Bourassa) Finished job 0 (smpi_app 'job0')
+> [1000.000000] (workload_executor@Bourassa) Launching the job executor of job 1 (app 'job1')
+> [1000.000000] (job_job1@Bourassa) Executing job 1 (smpi_app 'job1')
+> [1000.000000] (1_0@Bourassa) Replaying rank 0 of job 1 (smpi_app 'job1')
+> [1000.000000] (1_1@Fafard) Replaying rank 1 of job 1 (smpi_app 'job1')
+> [1737.001374] (1_0@Bourassa) Simulation time 737.001374
+> [1737.001374] (1_0@Bourassa) Finished replaying rank 0 of job 1 (smpi_app 'job1')
+> [1737.001374] (1_1@Fafard) Finished replaying rank 1 of job 1 (smpi_app 'job1')
+> [1737.001374] (job_job1@Bourassa) Finished job 1 (smpi_app 'job1')
+> [1737.001374] (maestro@) Simulation finished! Final time: 1737

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2_st.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2_st.tesh
@@ -1,0 +1,23 @@
+p Workload with two mixed jobs (at the same time but not on the same resources)
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml ${srcdir:=.}/workload_mixed2_same_time --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 0 0
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='job0', file='mixed.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (maestro@) Job read: app='job1', file='mixed.txt', size=2, start=0, alloc='2,3'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'job0')
+> [   0.000000] (job_job0@Bourassa) Executing job 0 (smpi_app 'job0')
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 1 (app 'job1')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (job_job1@Ginette) Executing job 1 (smpi_app 'job1')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (1_0@Ginette) Replaying rank 0 of job 1 (smpi_app 'job1')
+> [   0.000000] (1_1@Jupiter) Replaying rank 1 of job 1 (smpi_app 'job1')
+> [ 737.001374] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
+> [ 737.001374] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
+> [ 737.001374] (job_job0@Bourassa) Finished job 0 (smpi_app 'job0')
+> [ 806.923160] (1_0@Ginette) Simulation time 806.923160
+> [ 806.923160] (1_0@Ginette) Finished replaying rank 0 of job 1 (smpi_app 'job1')
+> [ 806.923160] (1_1@Jupiter) Finished replaying rank 1 of job 1 (smpi_app 'job1')
+> [ 806.923160] (job_job1@Ginette) Finished job 1 (smpi_app 'job1')
+> [ 806.923160] (maestro@) Simulation finished! Final time: 806.923

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2_st_noise.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2_st_noise.tesh
@@ -1,0 +1,23 @@
+p Workload with two mixed jobs (at the same time but not on the same resources)
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml ${srcdir:=.}/workload_mixed2_same_time --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 7 13
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='job0', file='mixed.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (maestro@) Job read: app='job1', file='mixed.txt', size=2, start=0, alloc='2,3'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'job0')
+> [   0.000000] (job_job0@Bourassa) Executing job 0 (smpi_app 'job0')
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 1 (app 'job1')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (job_job1@Ginette) Executing job 1 (smpi_app 'job1')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (1_0@Ginette) Replaying rank 0 of job 1 (smpi_app 'job1')
+> [   0.000000] (1_1@Jupiter) Replaying rank 1 of job 1 (smpi_app 'job1')
+> [ 737.001374] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
+> [ 737.001374] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
+> [ 737.001374] (job_job0@Bourassa) Finished job 0 (smpi_app 'job0')
+> [ 806.923160] (1_0@Ginette) Simulation time 806.923160
+> [ 806.923160] (1_0@Ginette) Finished replaying rank 0 of job 1 (smpi_app 'job1')
+> [ 806.923160] (1_1@Jupiter) Finished replaying rank 1 of job 1 (smpi_app 'job1')
+> [ 806.923160] (job_job1@Ginette) Finished job 1 (smpi_app 'job1')
+> [ 806.923160] (maestro@) Simulation finished! Final time: 806.923

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2_st_sr.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2_st_sr.tesh
@@ -1,0 +1,23 @@
+p Workload with two mixed jobs (at the same time and on the same resources)
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml ${srcdir:=.}/workload_mixed2_same_time_and_resources --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 0 0
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='job0', file='mixed.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (maestro@) Job read: app='job1', file='mixed.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'job0')
+> [   0.000000] (job_job0@Bourassa) Executing job 0 (smpi_app 'job0')
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 1 (app 'job1')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (job_job1@Bourassa) Executing job 1 (smpi_app 'job1')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (1_0@Bourassa) Replaying rank 0 of job 1 (smpi_app 'job1')
+> [   0.000000] (1_1@Fafard) Replaying rank 1 of job 1 (smpi_app 'job1')
+> [1473.975664] (1_0@Bourassa) Simulation time 1473.975664
+> [1473.975664] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
+> [1473.975664] (1_0@Bourassa) Finished replaying rank 0 of job 1 (smpi_app 'job1')
+> [1473.975664] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
+> [1473.975664] (job_job0@Bourassa) Finished job 0 (smpi_app 'job0')
+> [1473.975664] (1_1@Fafard) Finished replaying rank 1 of job 1 (smpi_app 'job1')
+> [1473.975664] (job_job1@Bourassa) Finished job 1 (smpi_app 'job1')
+> [1473.975664] (maestro@) Simulation finished! Final time: 1473.98

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2_st_sr_noise.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2_st_sr_noise.tesh
@@ -1,0 +1,23 @@
+p Workload with two mixed jobs (at the same time and on the same resources)
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml ${srcdir:=.}/workload_mixed2_same_time_and_resources --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 7 13
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Job read: app='job0', file='mixed.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (maestro@) Job read: app='job1', file='mixed.txt', size=2, start=0, alloc='0,1'
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 0 (app 'job0')
+> [   0.000000] (job_job0@Bourassa) Executing job 0 (smpi_app 'job0')
+> [   0.000000] (workload_executor@Bourassa) Launching the job executor of job 1 (app 'job1')
+> [   0.000000] (0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'job0')
+> [   0.000000] (job_job1@Bourassa) Executing job 1 (smpi_app 'job1')
+> [   0.000000] (0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (1_0@Bourassa) Replaying rank 0 of job 1 (smpi_app 'job1')
+> [   0.000000] (1_1@Fafard) Replaying rank 1 of job 1 (smpi_app 'job1')
+> [1473.975664] (1_0@Bourassa) Simulation time 1473.975664
+> [1473.975664] (0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
+> [1473.975664] (1_0@Bourassa) Finished replaying rank 0 of job 1 (smpi_app 'job1')
+> [1473.975664] (0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
+> [1473.975664] (job_job0@Bourassa) Finished job 0 (smpi_app 'job0')
+> [1473.975664] (1_1@Fafard) Finished replaying rank 1 of job 1 (smpi_app 'job1')
+> [1473.975664] (job_job1@Bourassa) Finished job 1 (smpi_app 'job1')
+> [1473.975664] (maestro@) Simulation finished! Final time: 1473.98

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_nojob.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_nojob.tesh
@@ -1,0 +1,7 @@
+# comment
+p Workload without any job
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml ${srcdir:=.}/workload_nojob --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 0 0
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   0.000000] (maestro@) Simulation finished! Final time: 0

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_nojob_noise.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_nojob_noise.tesh
@@ -1,0 +1,7 @@
+# comment
+p Workload without any job
+! timeout 120
+! output sort 19
+$ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_routers.xml ${srcdir:=.}/workload_nojob --log=smpi.:info --cfg=smpi/host-speed:100 "--log=root.fmt:[%11.6r]%e(%P@%h)%e%m%n" 7 13
+> [   0.000000] (maestro@) Configuration change: Set 'smpi/host-speed' to '100'
+> [   7.000000] (maestro@) Simulation finished! Final time: 7

--- a/examples/smpi/replay_multiple_manual_deploy/workload_compute
+++ b/examples/smpi/replay_multiple_manual_deploy/workload_compute
@@ -1,0 +1,10 @@
+One app alone
+alone compute_only.txt 2 0 0,1
+
+Two apps at the same time, but not on the same machines
+not_alone0 compute_only.txt 2 1000 0,1
+not_alone1 compute_only.txt 2 1001 2,3
+
+Two apps at the same time, on the same machines
+time_sharing0 compute_only.txt 2 2000 0,1
+time_sharing1 compute_only.txt 2 2001 0,1

--- a/examples/smpi/replay_multiple_manual_deploy/workload_compute_consecutive
+++ b/examples/smpi/replay_multiple_manual_deploy/workload_compute_consecutive
@@ -1,0 +1,9 @@
+One app alone
+alone0 compute_only.txt 2 0 0,1
+
+Another app alone
+alone1 compute_only.txt 2 1000 2,3
+
+And again ...
+alone2 compute_only.txt 2 2000 0,2
+alone3 compute_only.txt 2 3000 1,3

--- a/examples/smpi/replay_multiple_manual_deploy/workload_compute_consecutive2
+++ b/examples/smpi/replay_multiple_manual_deploy/workload_compute_consecutive2
@@ -1,0 +1,5 @@
+One app alone
+alone0 compute_only.txt 2 0 0,1
+
+Another app alone
+alone1 compute_only.txt 2 1000 2,3

--- a/examples/smpi/replay_multiple_manual_deploy/workload_compute_simple
+++ b/examples/smpi/replay_multiple_manual_deploy/workload_compute_simple
@@ -1,0 +1,2 @@
+One app alone
+alone compute_only.txt 2 0 0,1

--- a/examples/smpi/replay_multiple_manual_deploy/workload_empty1
+++ b/examples/smpi/replay_multiple_manual_deploy/workload_empty1
@@ -1,0 +1,2 @@
+One app alone
+alone empty.txt 2 0 0,1

--- a/examples/smpi/replay_multiple_manual_deploy/workload_empty2
+++ b/examples/smpi/replay_multiple_manual_deploy/workload_empty2
@@ -1,0 +1,4 @@
+Two jobs not at the same time nor on the same resources
+job0 empty.txt 2 0 0,1
+job1 empty.txt 2 1000 2,3
+

--- a/examples/smpi/replay_multiple_manual_deploy/workload_empty2_same_resources
+++ b/examples/smpi/replay_multiple_manual_deploy/workload_empty2_same_resources
@@ -1,0 +1,4 @@
+Two jobs not at the same time but using the same resources
+job0 empty.txt 2 0 0,1
+job1 empty.txt 2 1000 0,1
+

--- a/examples/smpi/replay_multiple_manual_deploy/workload_empty2_same_time
+++ b/examples/smpi/replay_multiple_manual_deploy/workload_empty2_same_time
@@ -1,0 +1,4 @@
+Two jobs not at the same time but on different resources
+job0 empty.txt 2 0 0,1
+job1 empty.txt 2 0 2,3
+

--- a/examples/smpi/replay_multiple_manual_deploy/workload_empty2_same_time_and_resources
+++ b/examples/smpi/replay_multiple_manual_deploy/workload_empty2_same_time_and_resources
@@ -1,0 +1,4 @@
+Two jobs not at the same time but on different resources
+job0 empty.txt 2 0 0,1
+job1 empty.txt 2 0 0,1
+

--- a/examples/smpi/replay_multiple_manual_deploy/workload_mixed1
+++ b/examples/smpi/replay_multiple_manual_deploy/workload_mixed1
@@ -1,0 +1,2 @@
+One app alone
+alone mixed.txt 2 0 0,1

--- a/examples/smpi/replay_multiple_manual_deploy/workload_mixed2
+++ b/examples/smpi/replay_multiple_manual_deploy/workload_mixed2
@@ -1,0 +1,4 @@
+Two jobs not at the same time nor on the same resources
+job0 mixed.txt 2 0 0,1
+job1 mixed.txt 2 1000 2,3
+

--- a/examples/smpi/replay_multiple_manual_deploy/workload_mixed2_same_resources
+++ b/examples/smpi/replay_multiple_manual_deploy/workload_mixed2_same_resources
@@ -1,0 +1,4 @@
+Two jobs not at the same time but using the same resources
+job0 mixed.txt 2 0 0,1
+job1 mixed.txt 2 1000 0,1
+

--- a/examples/smpi/replay_multiple_manual_deploy/workload_mixed2_same_time
+++ b/examples/smpi/replay_multiple_manual_deploy/workload_mixed2_same_time
@@ -1,0 +1,4 @@
+Two jobs not at the same time but on different resources
+job0 mixed.txt 2 0 0,1
+job1 mixed.txt 2 0 2,3
+

--- a/examples/smpi/replay_multiple_manual_deploy/workload_mixed2_same_time_and_resources
+++ b/examples/smpi/replay_multiple_manual_deploy/workload_mixed2_same_time_and_resources
@@ -1,0 +1,4 @@
+Two jobs not at the same time but on different resources
+job0 mixed.txt 2 0 0,1
+job1 mixed.txt 2 0 0,1
+

--- a/examples/smpi/replay_multiple_manual_deploy/workload_nojob
+++ b/examples/smpi/replay_multiple_manual_deploy/workload_nojob
@@ -1,0 +1,1 @@
+This workload does not compute any job.

--- a/tools/cmake/DefinePackages.cmake
+++ b/tools/cmake/DefinePackages.cmake
@@ -1001,6 +1001,7 @@ set(CMAKEFILES_TXT
     examples/smpi/NAS/CMakeLists.txt
     examples/smpi/smpi_msg_masterslave/CMakeLists.txt
     examples/smpi/replay_multiple/CMakeLists.txt
+    examples/smpi/replay_multiple_manual_deploy/CMakeLists.txt
     examples/smpi/energy/f77/CMakeLists.txt
     examples/smpi/energy/f90/CMakeLists.txt
 


### PR DESCRIPTION
This example shows how to mix S4U and SMPI (and MSG...)
to allow the (concurrent) dynamic replay of several SMPI traces.

This is heavily inspired from Batsim.

Related to issue #129 and to pull request #271.