### PR TITLE
Add method to check if a mailbox has a message ready to be consumed without having to wait

### DIFF
--- a/include/simgrid/s4u/Mailbox.hpp
+++ b/include/simgrid/s4u/Mailbox.hpp
@@ -131,6 +131,9 @@ public:
   /** Check if there is a communication going on in a mailbox. */
   bool listen();
 
+  /** Check if there is a communication ready to be consumed from a mailbox. */
+  bool ready();
+
   /** Gets the first element in the queue (without dequeuing it), or nullptr if none is there */
   smx_activity_t front();
 

--- a/src/s4u/s4u_Mailbox.cpp
+++ b/src/s4u/s4u_Mailbox.cpp
@@ -48,8 +48,8 @@ bool Mailbox::ready()
   bool comm_ready = false;
   if (not pimpl_->comm_queue_.empty()) {
     comm_ready = pimpl_->comm_queue_.front()->state_ == SIMIX_DONE;
-  }
-  if (!comm_ready && pimpl_->permanent_receiver_ && not pimpl_->done_comm_queue_.empty()) {
+    
+  } else if (pimpl_->permanent_receiver_ && not pimpl_->done_comm_queue_.empty()) {
     comm_ready = pimpl_->done_comm_queue_.front()->state_ == SIMIX_DONE;
   }
   return comm_ready;

--- a/src/s4u/s4u_Mailbox.cpp
+++ b/src/s4u/s4u_Mailbox.cpp
@@ -43,6 +43,18 @@ bool Mailbox::listen()
   return not this->empty() || (pimpl_->permanent_receiver_ && not pimpl_->done_comm_queue_.empty());
 }
 
+bool Mailbox::ready()
+{
+  bool comm_ready = false;
+  if (not pimpl_->comm_queue_.empty()) {
+    comm_ready = pimpl_->comm_queue_.front()->state_ == SIMIX_DONE;
+  }
+  if (!comm_ready && pimpl_->permanent_receiver_ && not pimpl_->done_comm_queue_.empty()) {
+    comm_ready = pimpl_->done_comm_queue_.front()->state_ == SIMIX_DONE;
+  }
+  return comm_ready;
+}
+
 smx_activity_t Mailbox::front()
 {
   return pimpl_->comm_queue_.empty() ? nullptr : pimpl_->comm_queue_.front();


### PR DESCRIPTION
I have the following scenario which I have not been able to simulate with the current SimGrid mailbox synchronization primitives

I have actors which operate in an infinite loop where they check if they have some message ready from one of theirs peers and if that's not the case they sleep for a fixed short amount of time before checking again.

In a sort of pseudo-code it looks like this:

**Initialization**
Every actor has a mailbox where they specify themselves as the receiver because that way according to `Mailbox.hpp`:
> It means that the communications sent to this mailbox will start flowing to
>   * its host even before he does a recv(). This models the real behavior of TCP
>   * and MPI communications, amongst other."

initialization code:

```
SomeActor::SomeActor(std::vector<std::string> args)
{
  simgrid::s4u::MailboxPtr my_mailbox = simgrid::s4u::Mailbox::by_name("for-actor-" + std::stoi(args[1]));
  my_mailbox->set_receiver(simgrid::s4u::Actor::self());
}
```

**Main loop**
```
void SomeActor::operator()()
  while (true) {
    // Send message to my peers if some condition occurs
    if (<some-condition>) {
      simgrid::s4u::MailboxPtr peer_mailbox = simgrid::s4u::Mailbox::by_name("for-actor-" + <some-peer-id-to-which-I-have-to-send-a-message>);
      // Send message and forget about it. Given that the mailboxes in use have the receiver set, the message will start flowing to it.
      peer_mailbox->put_init(<some-message>, <some-message-size>)->detach();
    }

    // Check if have a message from my peers ready to be consumed
    simgrid::s4u::MailboxPtr my_mailbox = simgrid::s4u::Mailbox::by_name("for-actor-" + std::stoi(args[1]));
    if (my_mailbox->ready()) {
       void* data = my_mailbox->get();
       // Do some processing with data
       // ...
    }

    // Sleep for a while until next iteration
    simgrid::s4u::this_actor::sleep_for(.1);
}

```

**Problem**

Right now I haven't found a way to solve the current scenario without the modification I'm proposing in the current pull request.

Option A)
I could use asynchronous messages, but they aren't compatible with the set_receiver method according to `s4u_Mailbox.cpp`:
> * All messages sent to this mailbox will be transferred to the receiver without waiting for the receive call.
> * The receive call will still be necessary to use the received data.
> * If there is a need to receive some messages asynchronously, and some not, two different mailboxes should be used.

Option B)
I could avoid using the set_receiver method to be able to use the asynchronous `get_async()` method but that way I would still need to have a `wait()` from the receiver actor in order for the message to start flowing to it. I could add a tiny timeout to this call but that would still be different from 0 which is not faithfully simulating what I need, which is start processing a message only if it's ready and if not continue with other things.

Option C)
I coult use set_receiver and the blocking get(timeout) method, eg: `get(0)`. This way the message starts flowing from the sender to the receiver when it's put into the receiver mailbox but if the receiver has a timeout in its `get()` method the communication is lost (I think)

**Proposed solution**
With the new `ready()` method in the `Mailbox` class, I can use the `set_receiver()` method for the messages to start flowing from the sender to the receiver when they are created and in the receiver I can check for `my_mailbox->ready()` before doing the "blocking" call to `my_mailbox->get()`.
 * If `my_mailbox->ready()` returns `true` then the next call to `my_mailbox->get()` will be completed immediately.
 * If `my_mailbox->ready()` returns `false` then I don't have a message from my peers ready to be consumed and I will sleep for a fixed amount of time before checking again (which is the scenario I'm trying to simulate)
