### PR TITLE
[s4u] Barrier refcounting

### DIFF
--- a/include/simgrid/forward.h
+++ b/include/simgrid/forward.h
@@ -24,6 +24,10 @@ XBT_PUBLIC void intrusive_ptr_release(Actor* actor);
 XBT_PUBLIC void intrusive_ptr_add_ref(Actor* actor);
 
 class Barrier;
+/** Smart pointer to a simgrid::s4u::Barrier */
+typedef boost::intrusive_ptr<Barrier> BarrierPtr;
+XBT_PUBLIC void intrusive_ptr_release(Barrier* m);
+XBT_PUBLIC void intrusive_ptr_add_ref(Barrier* m);
 
 class Comm;
 /** Smart pointer to a simgrid::s4u::Comm */

--- a/include/simgrid/s4u/Barrier.hpp
+++ b/include/simgrid/s4u/Barrier.hpp
@@ -6,10 +6,12 @@
 #ifndef SIMGRID_S4U_BARRIER_HPP
 #define SIMGRID_S4U_BARRIER_HPP
 
-#include "simgrid/s4u/ConditionVariable.hpp"
+#include <simgrid/forward.h>
+#include <simgrid/s4u/ConditionVariable.hpp>
 #include <simgrid/chrono.hpp>
 #include <simgrid/s4u/Mutex.hpp>
 
+#include <atomic>
 #include <future>
 
 namespace simgrid {
@@ -22,13 +24,23 @@ private:
   unsigned int expected_processes_;
   unsigned int arrived_processes_ = 0;
 
+  /* refcounting */
+  std::atomic_int_fast32_t refcount_{0};
+
 public:
   explicit Barrier(unsigned int count);
   ~Barrier()              = default;
   Barrier(Barrier const&) = delete;
   Barrier& operator=(Barrier const&) = delete;
 
+  /** Constructs a new barrier */
+  static BarrierPtr create(unsigned int expected_processes);
+
   int wait();
+
+  /* refcounting */
+  friend XBT_PUBLIC void intrusive_ptr_add_ref(Barrier* barrier);
+  friend XBT_PUBLIC void intrusive_ptr_release(Barrier* barrier);
 };
 }
 } // namespace simgrid::s4u


### PR DESCRIPTION
This PR adds a refcounted `BarrierPtr` for `s4u::Barrier`.
The code is inspired from `s4u::ExecPtr`, but I'm not very sure about this.

Tested with valgrind applying the following patch to the barrier example of #299.

```diff
diff --git examples/s4u/barrier/s4u-barrier.cpp examples/s4u/barrier/s4u-barrier.cpp
index 7be265965..2624745d8 100644
--- examples/s4u/barrier/s4u-barrier.cpp
+++ examples/s4u/barrier/s4u-barrier.cpp
@@ -3,13 +3,12 @@
 /* This program is free software; you can redistribute it and/or modify it
  * under the terms of the license (GNU LGPL) which comes with this package. */
 
-#include <memory>
 #include "simgrid/s4u.hpp"
 
 XBT_LOG_NEW_DEFAULT_CATEGORY(s4u_test, "a sample log category");
 
 /// Wait on the barrier then leave
-static void worker(std::shared_ptr<simgrid::s4u::Barrier> barrier)
+static void worker(simgrid::s4u::BarrierPtr barrier)
 {
     XBT_INFO("Waiting on the barrier");
     barrier->wait();
@@ -20,7 +19,7 @@ static void worker(std::shared_ptr<simgrid::s4u::Barrier> barrier)
 /// Spawn process_count-1 workers and do a barrier with them
 static void master(int process_count)
 {
-    std::shared_ptr<simgrid::s4u::Barrier> barrier(new simgrid::s4u::Barrier(process_count));
+    simgrid::s4u::BarrierPtr barrier = simgrid::s4u::Barrier::create(process_count);
 
     XBT_INFO("Spawning %d workers", process_count-1);
     for (int i = 0; i < process_count-1; i++)
```