### PR TITLE
Provide a pkg-config file for SimGrid

### DIFF
--- a/tools/cmake/Distrib.cmake
+++ b/tools/cmake/Distrib.cmake
@@ -64,6 +64,11 @@ if(enable_java)
       RENAME simgrid.jar)
 endif()
 
+# pkg-config files
+configure_file("${CMAKE_HOME_DIRECTORY}/tools/pkg-config/simgrid.pc.in"
+  "${PROJECT_BINARY_DIR}/simgrid.pc" @ONLY)
+install(FILES "${PROJECT_BINARY_DIR}/simgrid.pc" DESTINATION lib/pkgconfig/)
+
 # include files
 foreach(file ${headers_to_install}  ${generated_headers_to_install})
   get_filename_component(location ${file} PATH)

--- a/tools/pkg-config/simgrid.pc.in
+++ b/tools/pkg-config/simgrid.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: SimGrid
+Description: Framework for the simulation of distributed applications (Clouds, HPC, Grids, IoT and others)
+Version: @libsimgrid_version@
+
+Libs: -L${libdir} -lsimgrid
+Cflags: -I${includedir}


### PR DESCRIPTION
[pkg-config] eases the utilization of software components by letting the developers define how the components they work on should be used.

This commit generates and installs a very simple `simgrid.pc` for [pkg-config].
This allows users to include/link SimGrid without knowing internal details.

### Makefile usage example
``` Make
my-simulator: my-simulator.cpp
        g++ my-simulator.cpp ‘pkg-config --cflags --libs simgrid‘
```

### [Meson] usage example
``` Meson
project('my-simulator', 'cpp')
simgrid = dependency('simgrid')
executable('my-simulator', 'my-simulator.cpp', dependencies : simgrid)
```

[Meson]: https://mesonbuild.com/
[pkg-config]: https://www.freedesktop.org/wiki/Software/pkg-config/