### PR TITLE
argc, argv -> explicit parameters

### DIFF
--- a/examples/s4u/replay-comm/s4u-replay-comm.cpp
+++ b/examples/s4u/replay-comm/s4u-replay-comm.cpp
@@ -30,16 +30,9 @@ class Replayer {
 public:
   explicit Replayer(std::vector<std::string> args)
   {
-    int argc;
-    char* argv[2];
-    argv[0] = &args.at(0)[0];
-    if (args.size() == 1) {
-      argc = 1;
-    } else {
-      argc    = 2;
-      argv[1] = &args.at(1)[0];
-    }
-    simgrid::xbt::replay_runner(argc, argv);
+    const char* actor_name     = args[0].c_str();
+    const char* trace_filename = args[1].c_str();
+    simgrid::xbt::replay_runner(actor_name, trace_filename);
   }
 
   void operator()()
@@ -97,7 +90,6 @@ int main(int argc, char* argv[])
              argv[0], argv[0], argv[0]);
 
   e.load_platform(argv[1]);
-  e.register_default(&simgrid::xbt::replay_runner);
   e.register_actor<Replayer>("p0");
   e.register_actor<Replayer>("p1");
   e.load_deployment(argv[2]);

--- a/examples/s4u/replay-storage/s4u-replay-storage.cpp
+++ b/examples/s4u/replay-storage/s4u-replay-storage.cpp
@@ -40,16 +40,8 @@ class Replayer {
 public:
   explicit Replayer(std::vector<std::string> args)
   {
-    int argc;
-    char* argv[2];
-    argv[0] = &args.at(0)[0];
-    if (args.size() == 1) {
-      argc = 1;
-    } else {
-      argc    = 2;
-      argv[1] = &args.at(1)[0];
-    }
-    simgrid::xbt::replay_runner(argc, argv);
+    const char* actor_name = args[0].c_str();
+    simgrid::xbt::replay_runner(actor_name, nullptr);
   }
 
   void operator()()
@@ -112,7 +104,6 @@ int main(int argc, char* argv[])
              argv[0], argv[0], argv[0]);
 
   e.load_platform(argv[1]);
-  e.register_default(&simgrid::xbt::replay_runner);
   e.register_actor<Replayer>("p0");
   e.load_deployment(argv[2]);
 

--- a/examples/smpi/load_balancer_replay/load_balancer_replay.cpp
+++ b/examples/smpi/load_balancer_replay/load_balancer_replay.cpp
@@ -14,10 +14,11 @@ XBT_LOG_NEW_DEFAULT_CATEGORY(sampi_load_balancer_test, "Messages specific for th
 
 int main(int argc, char* argv[])
 {
+  /* Commenting this test, for now...
   sg_host_load_plugin_init();
   smpi_replay_init(&argc, &argv);
   sg_load_balancer_plugin_init(); // Must be called after smpi_replay_init as this will overwrite some replay actions
 
-  smpi_replay_main(&argc, &argv);
+  smpi_replay_main(&argc, &argv);*/
   return 0;
 }

--- a/examples/smpi/replay/replay.cpp
+++ b/examples/smpi/replay/replay.cpp
@@ -3,9 +3,11 @@
 /* This program is free software; you can redistribute it and/or modify it
  * under the terms of the license (GNU LGPL) which comes with this package. */
 
-#include "xbt/replay.hpp"
+#include "simgrid/s4u.hpp"
 #include "smpi/smpi.h"
 #include "xbt/asserts.h"
+#include "xbt/replay.hpp"
+#include "xbt/str.h"
 
 #include <string>
 
@@ -28,24 +30,13 @@ static void overriding_send(simgrid::xbt::ReplayAction& args)
 
 int main(int argc, char* argv[])
 {
-  /* Parse main arguments */
-  const char* instance_id    = "replay";
-  int rank                   = -1;
+  const char* instance_id = simgrid::s4u::Actor::self()->get_property("instance_id");
+  const int rank = xbt_str_parse_int(simgrid::s4u::Actor::self()->get_property("rank"), "Cannot parse rank");
   const char* trace_filename = argv[1];
   double start_delay_flops   = 0;
 
-  try {
-    rank = std::stoi(std::string(argv[0]));
-  } catch (std::invalid_argument&) {
-    throw std::invalid_argument(std::string("Invalid rank: ") + argv[0]);
-  }
-
   if (argc > 2) {
-    try {
-      start_delay_flops = std::stod(std::string(argv[2]));
-    } catch (std::invalid_argument&) {
-      throw std::invalid_argument(std::string(argv[2]) + " is not a double");
-    }
+    start_delay_flops = xbt_str_parse_double(argv[2], "Cannot parse start_delay_flops");
   }
 
   /* Setup things and register default actions */

--- a/examples/smpi/replay/replay.cpp
+++ b/examples/smpi/replay/replay.cpp
@@ -28,26 +28,26 @@ static void overriding_send(simgrid::xbt::ReplayAction& args)
 
 int main(int argc, char* argv[])
 {
-  const char* instance_id    = argv[1];
+  /* Parse main arguments */
+  const char* instance_id    = "replay";
   int rank                   = -1;
-  const char* trace_filename = argv[3];
+  const char* trace_filename = argv[1];
   double start_delay_flops   = 0;
 
   try {
-    rank = std::stoi(std::string(argv[2]));
+    rank = std::stoi(std::string(argv[0]));
   } catch (std::invalid_argument&) {
-    throw std::invalid_argument(std::string("Invalid rank: ") + argv[2]);
+    throw std::invalid_argument(std::string("Invalid rank: ") + argv[0]);
   }
 
-  if (argc > 4) {
+  if (argc > 2) {
     try {
-      start_delay_flops = std::stod(std::string(argv[4]));
+      start_delay_flops = std::stod(std::string(argv[2]));
     } catch (std::invalid_argument&) {
-      throw std::invalid_argument(std::string(argv[4]) + " is not a double");
+      throw std::invalid_argument(std::string(argv[2]) + " is not a double");
     }
   }
 
-  // XBT_INFO("\tinstance_id='%s' rank=%d trace_filename='%s'", instance_id, rank, trace_filename);
   /* Setup things and register default actions */
   smpi_replay_init(instance_id, rank, start_delay_flops);
 

--- a/examples/smpi/replay/replay.cpp
+++ b/examples/smpi/replay/replay.cpp
@@ -5,6 +5,12 @@
 
 #include "xbt/replay.hpp"
 #include "smpi/smpi.h"
+#include "xbt/asserts.h"
+
+#include <string>
+
+#include "xbt/log.h"
+XBT_LOG_NEW_DEFAULT_CATEGORY(msg_test, "Messages specific for this msg example");
 
 /* This shows how to extend the trace format by adding a new kind of events.
    This function is registered through xbt_replay_action_register() below. */
@@ -22,20 +28,42 @@ static void overriding_send(simgrid::xbt::ReplayAction& args)
 
 int main(int argc, char* argv[])
 {
+  const char* instance_id    = argv[1];
+  int rank                   = -1;
+  const char* trace_filename = argv[3];
+  double start_delay_flops   = 0;
+
+  try {
+    rank = std::stoi(std::string(argv[2]));
+  } catch (std::invalid_argument&) {
+    throw std::invalid_argument(std::string("Invalid rank: ") + argv[2]);
+  }
+
+  if (argc > 4) {
+    try {
+      start_delay_flops = std::stod(std::string(argv[4]));
+    } catch (std::invalid_argument&) {
+      throw std::invalid_argument(std::string(argv[4]) + " is not a double");
+    }
+  }
+
+  // XBT_INFO("\tinstance_id='%s' rank=%d trace_filename='%s'", instance_id, rank, trace_filename);
   /* Setup things and register default actions */
-  smpi_replay_init(&argc, &argv);
+  smpi_replay_init(instance_id, rank, start_delay_flops);
 
   /* Connect your callback function to the "blah" event in the trace files */
   xbt_replay_action_register("blah", action_blah);
 
   /* The send action is an override, so we have to first save its previous value in a global */
-  int rank;
-  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  int new_rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &new_rank);
+  if (new_rank != rank)
+    XBT_WARN("Rank inconsistency. Got %d, expected %d", new_rank, rank);
   if (rank == 0) {
     previous_send = xbt_replay_action_get("send");
     xbt_replay_action_register("send", overriding_send);
   }
   /* The regular run of the replayer */
-  smpi_replay_main(&argc, &argv);
+  smpi_replay_main(rank, trace_filename);
   return 0;
 }

--- a/examples/smpi/replay_multiple/replay_multiple.c
+++ b/examples/smpi/replay_multiple/replay_multiple.c
@@ -13,7 +13,16 @@
 XBT_LOG_NEW_DEFAULT_CATEGORY(msg_test, "Messages specific for this msg example");
 
 static int smpi_replay(int argc, char *argv[]) {
-  smpi_replay_run(&argc, &argv);
+  const char* instance_id    = argv[1];
+  int rank                   = xbt_str_parse_int(argv[2], "Cannot parse rank '%s'");
+  const char* trace_filename = argv[3];
+  double start_delay_flops   = 0;
+
+  if (argc > 4) {
+    start_delay_flops = xbt_str_parse_double(argv[4], "Cannot parse start_delay_flops");
+  }
+
+  smpi_replay_run(instance_id, rank, start_delay_flops, trace_filename);
   return 0;
 }
 

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual.cpp
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual.cpp
@@ -56,26 +56,12 @@ static bool job_comparator(const Job* j1, const Job* j2)
 
 static void smpi_replay_process(Job* job, simgrid::s4u::BarrierPtr barrier, int rank)
 {
-  // Prepare data for smpi_replay_run
-  int argc    = 5;
-  char** argv = xbt_new(char*, argc);
-  argv[0]     = xbt_strdup("1");                                 // log only?
-  argv[1]     = xbt_strdup(job->smpi_app_name.c_str());          // application instance
-  argv[2]     = bprintf("%d", rank);                             // rank
-  argv[3]     = xbt_strdup(job->traces_filenames[rank].c_str()); // smpi trace file for this rank
-  argv[4]     = xbt_strdup("0");                                 // ?
-
   XBT_INFO("Replaying rank %d of job %d (smpi_app '%s')", rank, job->unique_job_number, job->smpi_app_name.c_str());
-  smpi_replay_run(&argc, &argv);
+  smpi_replay_run(job->smpi_app_name.c_str(), rank, 0, job->traces_filenames[rank].c_str());
   XBT_INFO("Finished replaying rank %d of job %d (smpi_app '%s')", rank, job->unique_job_number,
            job->smpi_app_name.c_str());
 
   barrier->wait();
-
-  // Memory clean-up — leaks can come from argc/argv modifications from smpi_replay_run
-  for (int i = 0; i < argc; ++i)
-    xbt_free(argv[i]);
-  xbt_free(argv);
 }
 
 // Sleeps for a given amount of time

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2_st_sr.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2_st_sr.tesh
@@ -7,17 +7,17 @@ $ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_rout
 > [   0.000000] (maestro@) Job read: app='job1', file='mixed.txt', size=2, start=0, alloc='0,1'
 > [   0.000000] (workload@Bourassa) Launching the job executor of job 0 (app 'job0')
 > [   0.000000] (job_0000@Bourassa) Executing job 0 (smpi_app 'job0')
-> [   0.000000] (workload@Bourassa) Launching the job executor of job 1 (app 'job1')
-> [   0.000000] (job_0001@Bourassa) Executing job 1 (smpi_app 'job1')
 > [   0.000000] (rank_0_0@Bourassa) Replaying rank 0 of job 0 (smpi_app 'job0')
 > [   0.000000] (rank_0_1@Fafard) Replaying rank 1 of job 0 (smpi_app 'job0')
+> [   0.000000] (workload@Bourassa) Launching the job executor of job 1 (app 'job1')
+> [   0.000000] (job_0001@Bourassa) Executing job 1 (smpi_app 'job1')
 > [   0.000000] (rank_1_0@Bourassa) Replaying rank 0 of job 1 (smpi_app 'job1')
 > [   0.000000] (rank_1_1@Fafard) Replaying rank 1 of job 1 (smpi_app 'job1')
-> [1473.975664] (rank_1_0@Bourassa) Simulation time 1473.975664
-> [1473.975664] (rank_0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
+> [1473.975664] (rank_0_0@Bourassa) Simulation time 1473.975664
 > [1473.975664] (rank_1_0@Bourassa) Finished replaying rank 0 of job 1 (smpi_app 'job1')
-> [1473.975664] (rank_0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
+> [1473.975664] (rank_0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
 > [1473.975664] (rank_1_1@Fafard) Finished replaying rank 1 of job 1 (smpi_app 'job1')
+> [1473.975664] (rank_0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
 > [1474.975664] (job_0000@Bourassa) Finished job 0 (smpi_app 'job0')
 > [1474.975664] (job_0001@Bourassa) Finished job 1 (smpi_app 'job1')
 > [1474.975664] (maestro@) Simulation finished! Final time: 1474.98

--- a/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2_st_sr_noise.tesh
+++ b/examples/smpi/replay_multiple_manual_deploy/replay_multiple_manual_mixed2_st_sr_noise.tesh
@@ -13,11 +13,11 @@ $ ./replay_multiple_manual ${srcdir:=.}/../../platforms/small_platform_with_rout
 > [   0.000000] (job_0001@Bourassa) Executing job 1 (smpi_app 'job1')
 > [   0.000000] (rank_1_0@Bourassa) Replaying rank 0 of job 1 (smpi_app 'job1')
 > [   0.000000] (rank_1_1@Fafard) Replaying rank 1 of job 1 (smpi_app 'job1')
-> [1473.975664] (rank_1_0@Bourassa) Simulation time 1473.975664
-> [1473.975664] (rank_0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
+> [1473.975664] (rank_0_0@Bourassa) Simulation time 1473.975664
 > [1473.975664] (rank_1_0@Bourassa) Finished replaying rank 0 of job 1 (smpi_app 'job1')
-> [1473.975664] (rank_0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
+> [1473.975664] (rank_0_0@Bourassa) Finished replaying rank 0 of job 0 (smpi_app 'job0')
 > [1473.975664] (rank_1_1@Fafard) Finished replaying rank 1 of job 1 (smpi_app 'job1')
+> [1473.975664] (rank_0_1@Fafard) Finished replaying rank 1 of job 0 (smpi_app 'job0')
 > [1474.975664] (job_0000@Bourassa) Finished job 0 (smpi_app 'job0')
 > [1474.975664] (job_0001@Bourassa) Finished job 1 (smpi_app 'job1')
 > [1474.975664] (maestro@) Simulation finished! Final time: 1474.98

--- a/examples/smpi/smpi_msg_masterslave/deployment_masterslave_mailbox_smpi.xml
+++ b/examples/smpi/smpi_msg_masterslave/deployment_masterslave_mailbox_smpi.xml
@@ -13,27 +13,27 @@
     <argument value="0"/>
   </actor>
   <actor host="Ginette" function="master_mpi">
-    <argument value="master_mpi"/>
-    <argument value="0"/>
+    <prop id="instance_id" value="master_mpi"/>
+    <prop id="rank" value="0"/>
   </actor>
   <actor host="Bourassa" function="master_mpi">
-    <argument value="master_mpi"/>
-    <argument value="1"/>
+    <prop id="instance_id" value="master_mpi"/>
+    <prop id="rank" value="1"/>
   </actor>
   <actor host="Ginette" function="alltoall_mpi">
-    <argument value="alltoall_mpi"/>
-    <argument value="0"/>
+    <prop id="instance_id" value="alltoall_mpi"/>
+    <prop id="rank" value="0"/>
   </actor>
   <actor host="Bourassa" function="alltoall_mpi">
-    <argument value="alltoall_mpi"/>
-    <argument value="1"/>
+    <prop id="instance_id" value="alltoall_mpi"/>
+    <prop id="rank" value="1"/>
   </actor>
   <actor host="Jupiter" function="alltoall_mpi">
-    <argument value="alltoall_mpi"/>
-    <argument value="2"/>
+    <prop id="instance_id" value="alltoall_mpi"/>
+    <prop id="rank" value="2"/>
   </actor>
   <actor host="Fafard" function="alltoall_mpi">
-    <argument value="alltoall_mpi"/>
-    <argument value="3"/>
+    <prop id="instance_id" value="alltoall_mpi"/>
+    <prop id="rank" value="3"/>
   </actor>
 </platform>

--- a/include/simgrid/s4u/Actor.hpp
+++ b/include/simgrid/s4u/Actor.hpp
@@ -374,7 +374,7 @@ public:
     return res;
   }
   /** @deprecated See Actor::get_properties() */
-  XBT_ATTRIB_DEPRECATED_v323("Please use Actor::get_properties()") void setProperty(const char* key, const char* value)
+  XBT_ATTRIB_DEPRECATED_v323("Please use Actor::set_property()") void setProperty(const char* key, const char* value)
   {
     set_property(key, value);
   }

--- a/include/smpi/smpi.h
+++ b/include/smpi/smpi.h
@@ -1002,9 +1002,10 @@ XBT_PUBLIC int smpi_main(const char* program, int argc, char* argv[]);
 XBT_PUBLIC void smpi_process_init(int* argc, char*** argv);
 
 /* Trace replay specific stuff */
-XBT_PUBLIC void smpi_replay_init(int* argc, char*** argv); // Only initialization
-XBT_PUBLIC void smpi_replay_main(int* argc, char*** argv); // Launch the replay once init is done
-XBT_PUBLIC void smpi_replay_run(int* argc, char*** argv);  // Both init and start
+XBT_PUBLIC void smpi_replay_init(const char* instance_id, int rank, double start_delay_flops); // Only initialization
+XBT_PUBLIC void smpi_replay_main(int rank, const char* trace_filename); // Launch the replay once init is done
+XBT_PUBLIC void smpi_replay_run(const char* instance_id, int rank, double start_delay_flops,
+                                const char* trace_filename); // Both init and start
 
 XBT_PUBLIC void SMPI_app_instance_register(const char* name, xbt_main_func_t code, int num_processes);
 XBT_PUBLIC void SMPI_init();

--- a/include/xbt/replay.hpp
+++ b/include/xbt/replay.hpp
@@ -21,7 +21,7 @@ namespace xbt {
 typedef std::vector<std::string> ReplayAction;
 
 XBT_PUBLIC_DATA std::ifstream* action_fs;
-XBT_PUBLIC int replay_runner(int argc, char* argv[]);
+XBT_PUBLIC int replay_runner(const char* actor_name, const char* trace_filename);
 }
 }
 

--- a/src/smpi/bindings/smpi_pmpi.cpp
+++ b/src/smpi/bindings/smpi_pmpi.cpp
@@ -32,29 +32,9 @@ int PMPI_Init(int *argc, char ***argv)
   xbt_assert(simgrid::s4u::Engine::is_initialized(),
              "Your MPI program was not properly initialized. The easiest is to use smpirun to start it.");
 
-  const char* default_instance_id = "smpirun";
-  const char* instance_id         = default_instance_id;
-  int rank                        = simgrid::s4u::this_actor::get_pid() + 1;
-
-  // Yes, user can call MPI_INIT(NULL, NULL)...
-  if ((argc != nullptr) && (argv != nullptr)) {
-    if (*argc > 1)
-      instance_id = (*argv)[1];
-    if (*argc > 2)
-      rank = xbt_str_parse_int((*argv)[2], "Cannot parse rank");
-
-    // Remove SMPI positional arguments from argc/argv, so users do not see them.
-    if (*argc > 3) {
-      memmove(&(*argv)[0], &(*argv)[2], sizeof(char*) * (*argc - 2));
-      (*argv)[(*argc) - 1] = nullptr;
-      (*argv)[(*argc) - 2] = nullptr;
-    }
-    (*argc) -= 2;
-  }
-
   // Init is called only once per SMPI process
   if (not smpi_process()->initializing()){
-    simgrid::smpi::ActorExt::init(instance_id, rank);
+    simgrid::smpi::ActorExt::init();
   }
   if (not smpi_process()->initialized()){
     int rank_traced = simgrid::s4u::this_actor::get_pid();

--- a/src/smpi/include/smpi_actor.hpp
+++ b/src/smpi/include/smpi_actor.hpp
@@ -41,7 +41,7 @@ private:
 public:
   explicit ActorExt(simgrid::s4u::ActorPtr actor, simgrid::s4u::Barrier* barrier);
   ~ActorExt();
-  void set_data(int* argc, char*** argv);
+  void set_data(const char* instance_id);
   void finalize();
   int finalized();
   int initializing();
@@ -68,7 +68,7 @@ public:
   void set_comm_intra(MPI_Comm comm);
   void set_sampling(int s);
   int sampling();
-  static void init(int* argc, char*** argv);
+  static void init(const char* instance_id, int rank);
   simgrid::s4u::ActorPtr get_actor();
   int get_optind();
   void set_optind(int optind);

--- a/src/smpi/include/smpi_actor.hpp
+++ b/src/smpi/include/smpi_actor.hpp
@@ -68,7 +68,7 @@ public:
   void set_comm_intra(MPI_Comm comm);
   void set_sampling(int s);
   int sampling();
-  static void init(const char* instance_id, int rank);
+  static void init();
   simgrid::s4u::ActorPtr get_actor();
   int get_optind();
   void set_optind(int optind);

--- a/src/smpi/internals/smpi_actor.cpp
+++ b/src/smpi/internals/smpi_actor.cpp
@@ -61,20 +61,14 @@ ActorExt::~ActorExt()
   xbt_mutex_destroy(mailboxes_mutex_);
 }
 
-void ActorExt::set_data(int* argc, char*** argv)
+void ActorExt::set_data(const char* instance_id)
 {
-  instance_id_                   = std::string((*argv)[1]);
+  instance_id_                   = std::string(instance_id);
   comm_world_                    = smpi_deployment_comm_world(instance_id_);
   simgrid::s4u::Barrier* barrier = smpi_deployment_finalization_barrier(instance_id_);
   if (barrier != nullptr) // don't overwrite the current one if the instance has none
     finalization_barrier_ = barrier;
 
-  if (*argc > 3) {
-    memmove(&(*argv)[0], &(*argv)[2], sizeof(char*) * (*argc - 2));
-    (*argv)[(*argc) - 1] = nullptr;
-    (*argv)[(*argc) - 2] = nullptr;
-  }
-  (*argc) -= 2;
   // set the process attached to the mailbox
   mailbox_small_->set_receiver(actor_);
   XBT_DEBUG("<%ld> SMPI process has been initialized: %p", actor_->get_pid(), actor_.get());
@@ -233,14 +227,14 @@ int ActorExt::sampling()
   return sampling_;
 }
 
-void ActorExt::init(int* argc, char*** argv)
+void ActorExt::init(const char* instance_id, int rank)
 {
-
   if (smpi_process_count() == 0) {
     xbt_die("SimGrid was not initialized properly before entering MPI_Init. Aborting, please check compilation process "
             "and use smpirun\n");
   }
-  if (argc != nullptr && argv != nullptr) {
+
+  if (true) { // wut?
     simgrid::s4u::ActorPtr proc = simgrid::s4u::Actor::self();
     proc->get_impl()->context_->set_cleanup(&SIMIX_process_cleanup);
     // cheinrich: I'm not sure what the impact of the SMPI_switch_data_segment on this call is. I moved
@@ -251,14 +245,7 @@ void ActorExt::init(int* argc, char*** argv)
       return;
       
     process->state_ = SmpiProcessState::INITIALIZING;
-    
-    char* instance_id = (*argv)[1];
-    try {
-      int rank = std::stoi(std::string((*argv)[2]));
-      smpi_deployment_register_process(instance_id, rank, proc);
-    } catch (std::invalid_argument& ia) {
-      throw std::invalid_argument(std::string("Invalid rank: ") + (*argv)[2]);
-    }
+    smpi_deployment_register_process(instance_id, rank, proc);
 
     if (smpi_privatize_global_variables == SmpiPrivStrategies::MMAP) {
       /* Now using the segment index of this process  */
@@ -267,8 +254,8 @@ void ActorExt::init(int* argc, char*** argv)
       SMPI_switch_data_segment(proc);
     }
 
-    process->set_data(argc, argv);
-  } 
+    process->set_data(instance_id);
+  }
 }
 
 int ActorExt::get_optind()

--- a/src/smpi/internals/smpi_global.cpp
+++ b/src/smpi/internals/smpi_global.cpp
@@ -432,6 +432,10 @@ static int smpi_run_entry_point(smpi_entry_point_type entry_point, const std::st
   std::vector<char*>* args4argv = new std::vector<char*>(args.size());
   std::transform(begin(args), end(args), begin(*args4argv), [](const std::string& s) { return xbt_strdup(s.c_str()); });
 
+  // set argv[0] to executable_path
+  xbt_free((*args4argv)[0]);
+  (*args4argv)[0] = xbt_strdup(executable_path.c_str());
+
 #if !SMPI_IFORT
   // take a copy of args4argv to keep reference of the allocated strings
   const std::vector<char*> args2str(*args4argv);

--- a/src/smpi/internals/smpi_global.cpp
+++ b/src/smpi/internals/smpi_global.cpp
@@ -129,7 +129,11 @@ MPI_Comm smpi_process_comm_self(){
 }
 
 void smpi_process_init(int *argc, char ***argv){
-  simgrid::smpi::ActorExt::init(argc, argv);
+  xbt_assert(*argc > 2, "Expected argc>2, got %d", *argc);
+  const char* instance_id = (*argv)[1];
+  int rank                = xbt_str_parse_int((*argv)[2], "Cannot parse rank");
+
+  simgrid::smpi::ActorExt::init(instance_id, rank);
 }
 
 void * smpi_process_get_user_data(){
@@ -423,7 +427,8 @@ typedef std::function<int(int argc, char *argv[])> smpi_entry_point_type;
 typedef int (* smpi_c_entry_point_type)(int argc, char **argv);
 typedef void (*smpi_fortran_entry_point_type)();
 
-static int smpi_run_entry_point(smpi_entry_point_type entry_point, std::vector<std::string> args)
+static int smpi_run_entry_point(smpi_entry_point_type entry_point, std::vector<std::string> args,
+                                const char* instance_id)
 {
   // copy C strings, we need them writable
   std::vector<char*>* args4argv = new std::vector<char*>(args.size());
@@ -437,7 +442,8 @@ static int smpi_run_entry_point(smpi_entry_point_type entry_point, std::vector<s
   args4argv->push_back(nullptr);
   char** argv = args4argv->data();
 
-  simgrid::smpi::ActorExt::init(&argc, &argv);
+  int rank = xbt_str_parse_int(argv[2], "cannot parse rank in argv[2]");
+  simgrid::smpi::ActorExt::init(instance_id, rank);
 #if SMPI_IFORT
   for_rtl_init_ (&argc, argv);
 #elif SMPI_FLANG
@@ -539,7 +545,7 @@ static int visit_libs(struct dl_phdr_info* info, size_t, void* data)
 }
 #endif
 
-static void smpi_init_privatization_dlopen(std::string executable)
+static void smpi_init_privatization_dlopen(std::string executable, const char* instance_id)
 {
   // Prepare the copy of the binary (get its size)
   struct stat fdin_stat;
@@ -573,9 +579,8 @@ static void smpi_init_privatization_dlopen(std::string executable)
     }
   }
 
-  simix_global->default_function = [executable, fdin_size](std::vector<std::string> args) {
-    return std::function<void()>([executable, fdin_size, args] {
-
+  simix_global->default_function = [executable, fdin_size, instance_id](std::vector<std::string> args) {
+    return std::function<void()>([executable, fdin_size, args, instance_id] {
       // Copy the dynamic library:
       std::string target_executable =
           executable + "_" + std::to_string(getpid()) + "_" + std::to_string(rank) + ".so";
@@ -628,12 +633,12 @@ static void smpi_init_privatization_dlopen(std::string executable)
       smpi_entry_point_type entry_point = smpi_resolve_function(handle);
       if (not entry_point)
         xbt_die("Could not resolve entry point");
-      smpi_run_entry_point(entry_point, args);
+      smpi_run_entry_point(entry_point, args, instance_id);
     });
   };
 }
 
-static void smpi_init_privatization_no_dlopen(std::string executable)
+static void smpi_init_privatization_no_dlopen(std::string executable, const char* instance_id)
 {
   if (smpi_privatize_global_variables == SmpiPrivStrategies::MMAP)
     smpi_prepare_global_memory_segment();
@@ -648,8 +653,9 @@ static void smpi_init_privatization_no_dlopen(std::string executable)
     smpi_backup_global_memory_segment();
 
   // Execute the same entry point for each simulated process:
-  simix_global->default_function = [entry_point](std::vector<std::string> args) {
-    return std::function<void()>([entry_point, args] { smpi_run_entry_point(entry_point, args); });
+  simix_global->default_function = [entry_point, instance_id](std::vector<std::string> args) {
+    return std::function<void()>(
+        [entry_point, args, instance_id] { smpi_run_entry_point(entry_point, args, instance_id); });
   };
 }
 
@@ -679,14 +685,15 @@ int smpi_main(const char* executable, int argc, char* argv[])
   SIMIX_comm_set_copy_data_callback(smpi_comm_copy_buffer_callback);
 
   smpi_init_options();
+  const char* instance_id = smpi_default_instance_name.c_str();
   if (smpi_privatize_global_variables == SmpiPrivStrategies::DLOPEN)
-    smpi_init_privatization_dlopen(executable);
+    smpi_init_privatization_dlopen(executable, instance_id);
   else
-    smpi_init_privatization_no_dlopen(executable);
+    smpi_init_privatization_no_dlopen(executable, instance_id);
 
   SMPI_init();
   simgrid::s4u::Engine::get_instance()->load_deployment(argv[2]);
-  SMPI_app_instance_register(smpi_default_instance_name.c_str(), nullptr,
+  SMPI_app_instance_register(instance_id, nullptr,
                              process_data.size()); // This call has a side effect on process_count...
   MPI_COMM_WORLD = *smpi_deployment_comm_world(smpi_default_instance_name);
   smpi_universe_size = process_count;

--- a/src/smpi/internals/smpi_replay.cpp
+++ b/src/smpi/internals/smpi_replay.cpp
@@ -705,7 +705,9 @@ static std::unordered_map<aid_t, simgrid::smpi::replay::RequestStorage> storage;
 void smpi_replay_init(const char* instance_id, int rank, double start_delay_flops)
 {
   if (not smpi_process()->initializing()){
-    simgrid::smpi::ActorExt::init(instance_id, rank);
+    simgrid::s4u::Actor::self()->set_property("instance_id", instance_id);
+    simgrid::s4u::Actor::self()->set_property("rank", std::to_string(rank));
+    simgrid::smpi::ActorExt::init();
   }
   smpi_process()->mark_as_initialized();
   smpi_process()->set_replaying(true);

--- a/src/smpi/internals/smpi_replay.cpp
+++ b/src/smpi/internals/smpi_replay.cpp
@@ -702,10 +702,10 @@ void AllToAllVAction::kernel(simgrid::xbt::ReplayAction& action)
 
 static std::unordered_map<aid_t, simgrid::smpi::replay::RequestStorage> storage;
 /** @brief Only initialize the replay, don't do it for real */
-void smpi_replay_init(int* argc, char*** argv)
+void smpi_replay_init(const char* instance_id, int rank, double start_delay_flops)
 {
   if (not smpi_process()->initializing()){
-    simgrid::smpi::ActorExt::init(argc, argv);
+    simgrid::smpi::ActorExt::init(instance_id, rank);
   }
   smpi_process()->mark_as_initialized();
   smpi_process()->set_replaying(true);
@@ -744,10 +744,9 @@ void smpi_replay_init(int* argc, char*** argv)
   xbt_replay_action_register("compute", [](simgrid::xbt::ReplayAction& action) { simgrid::smpi::replay::ComputeAction().execute(action); });
 
   //if we have a delayed start, sleep here.
-  if(*argc>2){
-    double value = xbt_str_parse_double((*argv)[2], "%s is not a double");
-    XBT_VERB("Delayed start for instance - Sleeping for %f flops ",value );
-    smpi_execute_flops(value);
+  if (start_delay_flops > 0) {
+    XBT_VERB("Delayed start for instance - Sleeping for %f flops ", start_delay_flops);
+    smpi_execute_flops(start_delay_flops);
   } else {
     // Wait for the other actors to initialize also
     simgrid::s4u::this_actor::yield();
@@ -755,12 +754,13 @@ void smpi_replay_init(int* argc, char*** argv)
 }
 
 /** @brief actually run the replay after initialization */
-void smpi_replay_main(int* argc, char*** argv)
+void smpi_replay_main(int rank, const char* trace_filename)
 {
   static int active_processes = 0;
   active_processes++;
   storage[simgrid::s4u::this_actor::get_pid()] = simgrid::smpi::replay::RequestStorage();
-  simgrid::xbt::replay_runner(*argc, *argv);
+  std::string rank_string                      = std::to_string(rank);
+  simgrid::xbt::replay_runner(rank_string.c_str(), trace_filename);
 
   /* and now, finalize everything */
   /* One active process will stop. Decrease the counter*/
@@ -794,8 +794,8 @@ void smpi_replay_main(int* argc, char*** argv)
 }
 
 /** @brief chain a replay initialization and a replay start */
-void smpi_replay_run(int* argc, char*** argv)
+void smpi_replay_run(const char* instance_id, int rank, double start_delay_flops, const char* trace_filename)
 {
-  smpi_replay_init(argc, argv);
-  smpi_replay_main(argc, argv);
+  smpi_replay_init(instance_id, rank, start_delay_flops);
+  smpi_replay_main(rank, trace_filename);
 }

--- a/src/smpi/smpirun.in
+++ b/src/smpi/smpirun.in
@@ -424,8 +424,8 @@ do
     fi
 
     echo "  <actor host=\"${host}\" function=\"$i\"> <!-- function name used only for logging -->
-    <argument value=\"smpirun\"/> <!-- instance -->
-    <argument value=\"$i\"/> <!-- rank -->" >> ${APPLICATIONTMP}
+    <prop id=\"instance_id\" value=\"smpirun\"/>
+    <prop id=\"rank\" value=\"$i\"/>" >> ${APPLICATIONTMP}
     if [ ${REPLAY} = 1 ]; then
         if  [ ${NUMTRACES} -gt 1 ]; then
             echo "    <argument value=\"$(echo $hosttraces|cut -d' ' -f$j)\"/>" >> ${APPLICATIONTMP}


### PR DESCRIPTION
### Motivation
The ``smpi-replay-multiple-manual`` examples leaked memory which could not be avoided without a dirty hack in the example, requiring the example to know deep implementation details of the library.

After some investigation the argc/argv hack was deep within SMPI and required (small) modification in several parts of the code base.

### Impact overview
Pros
- Way clearer smpi-replay API
- SMPI made a bit more modular, which may be required soon to reuse its code from OpenMPI

Cons
- Reading of argc/argv is not centralized deeply anymore, the external interface**s** (online/offline) are in charge of handling them.

### Content
This PR decreases the usage of argc/argv to use explicit parameters instead — removing the argc/argv hacks in the replay part of the library.

As the argc/argv hack was in the common part of SMPI (smpi actors), this update also required modification to the code in charge of online SMPI simulation.

Most smpi-replay examples have been slightly modified because of the API change of this part.

Online SMPI examples have not been modified but ``tesh-smpi-coll-allreduce`` — just to adapt argc/argv as the example uses them.