### PR TITLE
Fix a doc error about actors (Tutorial_algorithms)

### DIFF
--- a/docs/source/Tutorial_Algorithms.rst
+++ b/docs/source/Tutorial_Algorithms.rst
@@ -85,7 +85,7 @@ the opportunity to improve this scheme.
 The Actors
 ..........
 
-Let's start with the code of the worker. It is represented by the
+Let's start with the code of the master. It is represented by the
 *master* function below. This simple function takes at least 3
 parameters (the amount of tasks to dispatch, their computational size
 in flops to compute and their communication size in bytes to


### PR DESCRIPTION
In the "[Simulating Algorithms](https://simgrid.org/doc/latest/Tutorial_Algorithms.html)" section of the docs, a master / worker application is used as an example. I think that when presenting actors a "worker" has been written in place of "master"