### PR TITLE
Add Mailbox  set_receiver method to python binding

### DIFF
--- a/src/bindings/python/simgrid_python.cpp
+++ b/src/bindings/python/simgrid_python.cpp
@@ -256,7 +256,13 @@ PYBIND11_MODULE(simgrid, m)
             // data.dec_ref(); // FIXME: why does it break python-actor-create?
             return data;
           },
-          py::call_guard<GilScopedRelease>(), "Blocking data reception");
+          py::call_guard<GilScopedRelease>(), "Blocking data reception")
+      .def("set_receiver",
+	 [](Mailbox* self, ActorPtr actor) {
+	   self->set_receiver(actor);
+	 },
+	 py::call_guard<GilScopedRelease>(),
+	 "Sets the actor as permanent receiver");
 
   /* Class Comm */
   py::class_<simgrid::s4u::Comm, simgrid::s4u::CommPtr>(m, "Comm", "Communication")

--- a/src/bindings/python/simgrid_python.cpp
+++ b/src/bindings/python/simgrid_python.cpp
@@ -256,13 +256,7 @@ PYBIND11_MODULE(simgrid, m)
             // data.dec_ref(); // FIXME: why does it break python-actor-create?
             return data;
           },
-          py::call_guard<GilScopedRelease>(), "Blocking data reception")
-    .def("set_receiver",
-	 [](Mailbox* self, ActorPtr actor) {
-	   self->set_receiver(actor);
-	 },
-	 py::call_guard<GilScopedRelease>(),
-	 "Sets the actor as permanent receiver");
+          py::call_guard<GilScopedRelease>(), "Blocking data reception");
 
   /* Class Comm */
   py::class_<simgrid::s4u::Comm, simgrid::s4u::CommPtr>(m, "Comm", "Communication")
@@ -292,16 +286,8 @@ PYBIND11_MODULE(simgrid, m)
           },
           "Amount of work remaining until completion from 0 (completely done) to 1 (nothing done "
           "yet).")
-      .def_property(
-          "host",
-          [](simgrid::s4u::ExecPtr self) {
-            simgrid::s4u::ExecSeqPtr seq = boost::dynamic_pointer_cast<simgrid::s4u::ExecSeq>(self);
-            if (seq != nullptr)
-              return seq->get_host();
-            xbt_throw_unimplemented(__FILE__, __LINE__,
-                                    "host of parallel executions is not implemented in python yet.");
-          },
-          &simgrid::s4u::Exec::set_host, "Host on which this execution runs.")
+      .def_property("host", &simgrid::s4u::Exec::get_host, &simgrid::s4u::Exec::set_host,
+                    "Host on which this execution runs. Only the first host is returned for parallel executions.")
       .def("test", &simgrid::s4u::Exec::test, py::call_guard<GilScopedRelease>(),
            "Test whether the execution is terminated.")
       .def("cancel", &simgrid::s4u::Exec::cancel, py::call_guard<GilScopedRelease>(), "Cancel that execution.")

--- a/src/bindings/python/simgrid_python.cpp
+++ b/src/bindings/python/simgrid_python.cpp
@@ -256,7 +256,13 @@ PYBIND11_MODULE(simgrid, m)
             // data.dec_ref(); // FIXME: why does it break python-actor-create?
             return data;
           },
-          py::call_guard<GilScopedRelease>(), "Blocking data reception");
+          py::call_guard<GilScopedRelease>(), "Blocking data reception")
+    .def("set_receiver",
+	 [](Mailbox* self, ActorPtr actor) {
+	   self->set_receiver(actor);
+	 },
+	 py::call_guard<GilScopedRelease>(),
+	 "Sets the actor as permanent receiver");
 
   /* Class Comm */
   py::class_<simgrid::s4u::Comm, simgrid::s4u::CommPtr>(m, "Comm", "Communication")
@@ -286,8 +292,16 @@ PYBIND11_MODULE(simgrid, m)
           },
           "Amount of work remaining until completion from 0 (completely done) to 1 (nothing done "
           "yet).")
-      .def_property("host", &simgrid::s4u::Exec::get_host, &simgrid::s4u::Exec::set_host,
-                    "Host on which this execution runs. Only the first host is returned for parallel executions.")
+      .def_property(
+          "host",
+          [](simgrid::s4u::ExecPtr self) {
+            simgrid::s4u::ExecSeqPtr seq = boost::dynamic_pointer_cast<simgrid::s4u::ExecSeq>(self);
+            if (seq != nullptr)
+              return seq->get_host();
+            xbt_throw_unimplemented(__FILE__, __LINE__,
+                                    "host of parallel executions is not implemented in python yet.");
+          },
+          &simgrid::s4u::Exec::set_host, "Host on which this execution runs.")
       .def("test", &simgrid::s4u::Exec::test, py::call_guard<GilScopedRelease>(),
            "Test whether the execution is terminated.")
       .def("cancel", &simgrid::s4u::Exec::cancel, py::call_guard<GilScopedRelease>(), "Cancel that execution.")


### PR DESCRIPTION
Hello,
I  am implementing a scenario in Python where I need many different actors to send messages every x second to a "server"  mailbox and wait for some acknowledgement. 

- When using synchronous messages, in my understanding,  the communication only starts when the server actor call get() on its mailbox. In that case all client actors will block until the server can process their respective messages, as if they were sent sequentially which is not what we aim for in this scenario. 
- Using asynchronous sending from clients  doesn't solve this issue either. Sends from different client are also "serialized" and start only as soon as the previous send as ended. 

- According to the doc set_receiver can solve this issue, but is not defined in the python bindings. 

Therefore , I have added the corresponding code in the python binding.
Sorry for the messy commit history