### PR TITLE
cast hugepages macros parameters to int64

### DIFF
--- a/src/smpi/internals/smpi_shared.cpp
+++ b/src/smpi/internals/smpi_shared.cpp
@@ -142,8 +142,8 @@ static void *smpi_shared_malloc_local(size_t size, const char *file, int line)
 }
 
 // Align functions, from http://stackoverflow.com/questions/4840410/how-to-align-a-pointer-in-c
-#define ALIGN_UP(n, align) (((n) + (align)-1) & -(align))
-#define ALIGN_DOWN(n, align) ((n) & -(align))
+#define ALIGN_UP(n, align) ((((int64_t)n) + ((int64_t)align)-1) & -((int64_t)align))
+#define ALIGN_DOWN(n, align) (((int64_t)n) & -((int64_t)align))
 
 constexpr unsigned PAGE_SIZE      = 0x1000;
 constexpr unsigned HUGE_PAGE_SIZE = 1U << 21;
@@ -184,7 +184,7 @@ void* smpi_shared_malloc_partial(size_t size, size_t* shared_block_offsets, int 
                                 "to allow big allocations.\n",
              size >> 20);
   if(use_huge_page)
-    mem = (void*)ALIGN_UP((int64_t)allocated_ptr, HUGE_PAGE_SIZE);
+    mem = (void*)ALIGN_UP(allocated_ptr, HUGE_PAGE_SIZE);
   else
     mem = allocated_ptr;
 
@@ -235,8 +235,8 @@ void* smpi_shared_malloc_partial(size_t size, size_t* shared_block_offsets, int 
     if(i_block < nb_shared_blocks-1)
       xbt_assert(stop_offset < shared_block_offsets[2*i_block+2],
               "stop_offset (%zu) should be lower than its successor start offset (%zu)", stop_offset, shared_block_offsets[2*i_block+2]);
-    size_t start_block_offset = ALIGN_UP((int64_t)start_offset, smpi_shared_malloc_blocksize);
-    size_t stop_block_offset = ALIGN_DOWN((int64_t)stop_offset, smpi_shared_malloc_blocksize);
+    size_t start_block_offset = ALIGN_UP(start_offset, smpi_shared_malloc_blocksize);
+    size_t stop_block_offset = ALIGN_DOWN(stop_offset, smpi_shared_malloc_blocksize);
     for (size_t offset = start_block_offset; offset < stop_block_offset; offset += smpi_shared_malloc_blocksize) {
       XBT_DEBUG("\t\tglobal shared allocation, mmap block offset %zx", offset);
       void* pos = (void*)((unsigned long)mem + offset);
@@ -248,8 +248,8 @@ void* smpi_shared_malloc_partial(size_t size, size_t* shared_block_offsets, int 
                              "and that the directory you are passing is mounted correctly (mount /path/to/huge -t hugetlbfs -o rw,mode=0777).",
                  strerror(errno));
     }
-    size_t low_page_start_offset = ALIGN_UP((int64_t)start_offset, PAGE_SIZE);
-    size_t low_page_stop_offset = (int64_t)start_block_offset < ALIGN_DOWN((int64_t)stop_offset, PAGE_SIZE) ? start_block_offset : ALIGN_DOWN((int64_t)stop_offset, (int64_t)PAGE_SIZE);
+    size_t low_page_start_offset = ALIGN_UP(start_offset, PAGE_SIZE);
+    size_t low_page_stop_offset = (int64_t)start_block_offset < ALIGN_DOWN(stop_offset, PAGE_SIZE) ? start_block_offset : ALIGN_DOWN(stop_offset, PAGE_SIZE);
     if(low_page_start_offset < low_page_stop_offset) {
       XBT_DEBUG("\t\tglobal shared allocation, mmap block start");
       void* pos = (void*)((unsigned long)mem + low_page_start_offset);
@@ -263,7 +263,7 @@ void* smpi_shared_malloc_partial(size_t size, size_t* shared_block_offsets, int 
     }
     if(low_page_stop_offset <= stop_block_offset) {
       XBT_DEBUG("\t\tglobal shared allocation, mmap block stop");
-      size_t high_page_stop_offset = stop_offset == size ? size : ALIGN_DOWN((int64_t)stop_offset, PAGE_SIZE);
+      size_t high_page_stop_offset = stop_offset == size ? size : ALIGN_DOWN(stop_offset, PAGE_SIZE);
       if(high_page_stop_offset > stop_block_offset) {
         void* pos = (void*)((unsigned long)mem + stop_block_offset);
         const void* res = mmap(pos, high_page_stop_offset - stop_block_offset, PROT_READ | PROT_WRITE,

--- a/src/smpi/internals/smpi_shared.cpp
+++ b/src/smpi/internals/smpi_shared.cpp
@@ -184,7 +184,7 @@ void* smpi_shared_malloc_partial(size_t size, size_t* shared_block_offsets, int 
                                 "to allow big allocations.\n",
              size >> 20);
   if(use_huge_page)
-    mem = (void*)ALIGN_UP((int64_t)allocated_ptr, HUGE_PAGE_SIZE);
+    mem = (void*)ALIGN_UP((int64_t)allocated_ptr, (int64_t)HUGE_PAGE_SIZE);
   else
     mem = allocated_ptr;
 
@@ -235,8 +235,8 @@ void* smpi_shared_malloc_partial(size_t size, size_t* shared_block_offsets, int 
     if(i_block < nb_shared_blocks-1)
       xbt_assert(stop_offset < shared_block_offsets[2*i_block+2],
               "stop_offset (%zu) should be lower than its successor start offset (%zu)", stop_offset, shared_block_offsets[2*i_block+2]);
-    size_t start_block_offset = ALIGN_UP((int64_t)start_offset, smpi_shared_malloc_blocksize);
-    size_t stop_block_offset = ALIGN_DOWN((int64_t)stop_offset, smpi_shared_malloc_blocksize);
+    size_t start_block_offset = ALIGN_UP((int64_t)start_offset, (int64_t)smpi_shared_malloc_blocksize);
+    size_t stop_block_offset = ALIGN_DOWN((int64_t)stop_offset, (int64_t)smpi_shared_malloc_blocksize);
     for (size_t offset = start_block_offset; offset < stop_block_offset; offset += smpi_shared_malloc_blocksize) {
       XBT_DEBUG("\t\tglobal shared allocation, mmap block offset %zx", offset);
       void* pos = (void*)((unsigned long)mem + offset);
@@ -248,8 +248,8 @@ void* smpi_shared_malloc_partial(size_t size, size_t* shared_block_offsets, int 
                              "and that the directory you are passing is mounted correctly (mount /path/to/huge -t hugetlbfs -o rw,mode=0777).",
                  strerror(errno));
     }
-    size_t low_page_start_offset = ALIGN_UP((int64_t)start_offset, PAGE_SIZE);
-    size_t low_page_stop_offset = (int64_t)start_block_offset < ALIGN_DOWN((int64_t)stop_offset, PAGE_SIZE) ? start_block_offset : ALIGN_DOWN((int64_t)stop_offset, (int64_t)PAGE_SIZE);
+    size_t low_page_start_offset = ALIGN_UP((int64_t)start_offset, (int64_t)PAGE_SIZE);
+    size_t low_page_stop_offset = (int64_t)start_block_offset < ALIGN_DOWN((int64_t)stop_offset, (int64_t)PAGE_SIZE) ? start_block_offset : ALIGN_DOWN((int64_t)stop_offset, (int64_t)PAGE_SIZE);
     if(low_page_start_offset < low_page_stop_offset) {
       XBT_DEBUG("\t\tglobal shared allocation, mmap block start");
       void* pos = (void*)((unsigned long)mem + low_page_start_offset);
@@ -263,7 +263,7 @@ void* smpi_shared_malloc_partial(size_t size, size_t* shared_block_offsets, int 
     }
     if(low_page_stop_offset <= stop_block_offset) {
       XBT_DEBUG("\t\tglobal shared allocation, mmap block stop");
-      size_t high_page_stop_offset = stop_offset == size ? size : ALIGN_DOWN((int64_t)stop_offset, PAGE_SIZE);
+      size_t high_page_stop_offset = stop_offset == size ? size : ALIGN_DOWN((int64_t)stop_offset, (int64_t)PAGE_SIZE);
       if(high_page_stop_offset > stop_block_offset) {
         void* pos = (void*)((unsigned long)mem + stop_block_offset);
         const void* res = mmap(pos, high_page_stop_offset - stop_block_offset, PROT_READ | PROT_WRITE,


### PR DESCRIPTION
The two macros `ALIGN_UP` and `ALIGN_DOWN` used by the shared malloc hugepages gave the wrong result in a logical operation because of a different precision type.

The following minimal example ilustrates this:

```C++
#include <stdio.h>
#include <cstdint>

#define ALIGN_UP(n, align) (((n) + (align)-1) & -(align))
constexpr unsigned HUGE_PAGE_SIZE = 1U << 21;

int main(){

  void* mem;
  void* allocated_ptr = (void*)0x7ffdffef1000;

  mem = (void*)ALIGN_UP((int64_t)allocated_ptr, HUGE_PAGE_SIZE);
  printf("ap: %p\n", allocated_ptr);
  printf("mem: %p\n", mem);

}
```
The value `0x7ffdffef1000` is returned from `mmap` in simgrid code, but when `ALIGH_UP` is applied, `mem` is `NULL`.
The `align` parameter should be of the same type of `n` before the `-(align)`.

Some of the calls were already casting the second parameter.
