### PR TITLE
[SMPI] Fix shared-malloc with huge pages

### DIFF
--- a/src/smpi/internals/smpi_shared.cpp
+++ b/src/smpi/internals/smpi_shared.cpp
@@ -145,8 +145,8 @@ static void *smpi_shared_malloc_local(size_t size, const char *file, int line)
 #define ALIGN_UP(n, align) (((int64_t)(n) + (int64_t)(align) - 1) & -(int64_t)(align))
 #define ALIGN_DOWN(n, align) ((int64_t)(n) & -(int64_t)(align))
 
-constexpr unsigned PAGE_SIZE      = 0x1000;
-constexpr unsigned HUGE_PAGE_SIZE = 1U << 21;
+constexpr long unsigned PAGE_SIZE      = 0x1000;
+constexpr long unsigned HUGE_PAGE_SIZE = 1U << 21;
 
 /* Similar to smpi_shared_malloc, but only sharing the blocks described by shared_block_offsets.
  * This array contains the offsets (in bytes) of the block to share.


### PR DESCRIPTION
After updating my Simgrid installation to the latest stable release, I found out that I could not perform a shared-malloc with huge pages, I get the following error:
```
[dahu-13.grid5000.fr:401:(402) 0.007487] /tmp/simgrid/src/smpi/internals/smpi_shared.cpp:275: [root/CRITICAL] Could not map folded virtual memory (Cannot allocate memory). Do you perhaps need to increase the size of the mapped file using --cfg=smpi/shared-malloc-blocksize:newvalue (default 1048576) ?You can also try using  the sysctl vm.max_map_count
```

The problem has been introduced by b024b9e443552c94609fc56a240cdb199a329853

The constant `HUGE_PAGE_SIZE` needs to be a 64 bit integer, otherwise we get an integer overflow in [smpi_shared.cpp](https://github.com/simgrid/simgrid/blob/master/src/smpi/internals/smpi_shared.cpp#L187):
```c++
    mem = (void*)ALIGN_UP(allocated_ptr, HUGE_PAGE_SIZE);
```

**Note** that I could not test this pull request with the `master` branch due to the bug reported in #346. I tested it with v3.25 and it worked as expected.