### PR TITLE
"State" in model checkers

### DIFF
--- a/src/mc/checker/SafetyChecker.cpp
+++ b/src/mc/checker/SafetyChecker.cpp
@@ -180,8 +180,8 @@ void SafetyChecker::backtrack()
   stack_.pop_back();
 
   /* Check for deadlocks */
-  if (mc_model_checker->checkDeadlock()) {
-    MC_show_deadlock();
+  if (mcapi::get().mc_check_deadlock()) {
+    mcapi::get().mc_show_deadlock();
     throw DeadlockError();
   }
 
@@ -198,19 +198,19 @@ void SafetyChecker::backtrack()
       if (req->call_ == SIMCALL_MUTEX_LOCK || req->call_ == SIMCALL_MUTEX_TRYLOCK)
         xbt_die("Mutex is currently not supported with DPOR,  use --cfg=model-check/reduction:none");
 
-      const kernel::actor::ActorImpl* issuer = MC_smx_simcall_get_issuer(req);
+      const kernel::actor::ActorImpl* issuer = mcapi::get().mc_smx_simcall_get_issuer(req);
       for (auto i = stack_.rbegin(); i != stack_.rend(); ++i) {
         State* prev_state = i->get();
-        if (request_depend(req, &prev_state->internal_req_)) {
+        if (mcapi::get().request_depend(req, &prev_state->internal_req_)) {
           if (XBT_LOG_ISENABLED(mc_safety, xbt_log_priority_debug)) {
             XBT_DEBUG("Dependent Transitions:");
             int value              = prev_state->transition_.argument_;
             smx_simcall_t prev_req = &prev_state->executed_req_;
-            XBT_DEBUG("%s (state=%d)", simgrid::mc::request_to_string(prev_req, value, RequestType::internal).c_str(),
+            XBT_DEBUG("%s (state=%d)", mcapi::get().request_to_string(prev_req, value, RequestType::internal).c_str(),
                       prev_state->num_);
             value    = state->transition_.argument_;
             prev_req = &state->executed_req_;
-            XBT_DEBUG("%s (state=%d)", simgrid::mc::request_to_string(prev_req, value, RequestType::executed).c_str(),
+            XBT_DEBUG("%s (state=%d)", mcapi::get().request_to_string(prev_req, value, RequestType::executed).c_str(),
                       state->num_);
           }
 
@@ -220,14 +220,14 @@ void SafetyChecker::backtrack()
             XBT_DEBUG("Process %p is in done set", req->issuer_);
           break;
         } else if (req->issuer_ == prev_state->internal_req_.issuer_) {
-          XBT_DEBUG("Simcall %s and %s with same issuer", SIMIX_simcall_name(req->call_),
-                    SIMIX_simcall_name(prev_state->internal_req_.call_));
+          XBT_DEBUG("Simcall %s and %s with same issuer", mcapi::get().simix_simcall_name(req->call_),
+                    mcapi::get().simix_simcall_name(prev_state->internal_req_.call_));
           break;
         } else {
-          const kernel::actor::ActorImpl* previous_issuer = MC_smx_simcall_get_issuer(&prev_state->internal_req_);
+          const kernel::actor::ActorImpl* previous_issuer = mcapi::get().mc_smx_simcall_get_issuer(&prev_state->internal_req_);
           XBT_DEBUG("Simcall %s, process %ld (state %d) and simcall %s, process %ld (state %d) are independent",
-                    SIMIX_simcall_name(req->call_), issuer->get_pid(), state->num_,
-                    SIMIX_simcall_name(prev_state->internal_req_.call_), previous_issuer->get_pid(), prev_state->num_);
+                    mcapi::get().simix_simcall_name(req->call_), issuer->get_pid(), state->num_,
+                    mcapi::get().simix_simcall_name(prev_state->internal_req_.call_), previous_issuer->get_pid(), prev_state->num_);
         }
       }
     }

--- a/src/mc/checker/SafetyChecker.cpp
+++ b/src/mc/checker/SafetyChecker.cpp
@@ -37,16 +37,17 @@ namespace mc {
 void SafetyChecker::check_non_termination(const State* current_state)
 {
   for (auto state = stack_.rbegin(); state != stack_.rend(); ++state)
-    if (snapshot_equal((*state)->system_state_.get(), current_state->system_state_.get())) {
+    if (mcapi::get().snapshot_equal((*state)->system_state_.get(), current_state->system_state_.get())) {
       XBT_INFO("Non-progressive cycle: state %d -> state %d", (*state)->num_, current_state->num_);
       XBT_INFO("******************************************");
       XBT_INFO("*** NON-PROGRESSIVE CYCLE DETECTED ***");
       XBT_INFO("******************************************");
       XBT_INFO("Counter-example execution trace:");
-      for (auto const& s : mc_model_checker->getChecker()->get_textual_trace())
+      auto checker = mcapi::get().mc_get_checker();
+      for (auto const& s : checker->get_textual_trace())
         XBT_INFO("  %s", s.c_str());
-      dumpRecordPath();
-      session->log_state();
+      mcapi::get().mc_dump_record_path();
+      mcapi::get().s_log_state();
 
       throw TerminationError();
     }

--- a/src/mc/checker/SafetyChecker.cpp
+++ b/src/mc/checker/SafetyChecker.cpp
@@ -67,7 +67,7 @@ std::vector<std::string> SafetyChecker::get_textual_trace() // override
     int value         = state->transition_.argument_;
     smx_simcall_t req = &state->executed_req_;
     if (req)
-      trace.push_back(request_to_string(req, value, RequestType::executed));
+      trace.push_back(mcapi::get().request_to_string(req, value, RequestType::executed));
   }
   return trace;
 }

--- a/src/mc/checker/SafetyChecker.cpp
+++ b/src/mc/checker/SafetyChecker.cpp
@@ -75,8 +75,8 @@ std::vector<std::string> SafetyChecker::get_textual_trace() // override
 void SafetyChecker::log_state() // override
 {
   XBT_INFO("Expanded states = %lu", expanded_states_count_);
-  XBT_INFO("Visited states = %lu", mc_model_checker->visited_states);
-  XBT_INFO("Executed transitions = %lu", mc_model_checker->executed_transitions);
+  XBT_INFO("Visited states = %lu", mcapi::get().mc_get_visited_states());
+  XBT_INFO("Executed transitions = %lu", mcapi::get().mc_get_executed_trans());
 }
 
 void SafetyChecker::run()

--- a/src/mc/checker/SafetyChecker.cpp
+++ b/src/mc/checker/SafetyChecker.cpp
@@ -23,8 +23,11 @@
 #include "src/mc/mc_record.hpp"
 #include "src/mc/mc_request.hpp"
 #include "src/mc/mc_smx.hpp"
+#include "src/mc/mc_api.hpp"
 
 #include "src/xbt/mmalloc/mmprivate.h"
+
+using mcapi = simgrid::mc::mc_api;
 
 XBT_LOG_NEW_DEFAULT_SUBCATEGORY(mc_safety, mc, "Logging specific to MC safety verification ");
 
@@ -279,7 +282,8 @@ SafetyChecker::SafetyChecker(Session& s) : Checker(s)
     XBT_INFO("Check a safety property. Reduction is: %s.",
              (reductionMode_ == ReductionMode::none ? "none"
                                                     : (reductionMode_ == ReductionMode::dpor ? "dpor" : "unknown")));
-  session->initialize();
+  
+  mcapi::get().s_initialize();  
 
   XBT_DEBUG("Starting the safety algorithm");
 
@@ -290,8 +294,9 @@ SafetyChecker::SafetyChecker(Session& s) : Checker(s)
   XBT_DEBUG("Initial state");
 
   /* Get an enabled actor and insert it in the interleave set of the initial state */
-  for (auto& actor : mc_model_checker->get_remote_simulation().actors())
-    if (actor_is_enabled(actor.copy.get_buffer())) {
+  auto actors = mcapi::get().get_actors();
+  for (auto& actor : actors)
+    if (mcapi::get().actor_is_enabled(actor.copy.get_buffer()->get_pid())) {
       initial_state->add_interleaving_set(actor.copy.get_buffer());
       if (reductionMode_ != ReductionMode::none)
         break;

--- a/src/mc/checker/SafetyChecker.cpp
+++ b/src/mc/checker/SafetyChecker.cpp
@@ -250,21 +250,21 @@ void SafetyChecker::restore_state()
   /* Intermediate backtracking */
   const State* last_state = stack_.back().get();
   if (last_state->system_state_) {
-    last_state->system_state_->restore(&mc_model_checker->get_remote_simulation());
+    last_state->system_state_->restore(&mcapi::get().mc_get_remote_simulation());
     return;
   }
 
   /* Restore the initial state */
-  session->restore_initial_state();
+  mcapi::get().s_restore_initial_state();
 
   /* Traverse the stack from the state at position start and re-execute the transitions */
   for (std::unique_ptr<State> const& state : stack_) {
     if (state == stack_.back())
       break;
-    session->execute(state->transition_);
+    mcapi::get().execute(state->transition_);
     /* Update statistics */
-    mc_model_checker->visited_states++;
-    mc_model_checker->executed_transitions++;
+    mcapi::get().mc_inc_visited_states();
+    mcapi::get().mc_inc_executed_trans();
   }
 }
 

--- a/src/mc/mc_api.cpp
+++ b/src/mc/mc_api.cpp
@@ -1,0 +1,151 @@
+#include "mc_api.hpp"
+
+#include "src/mc/Session.hpp"
+#include "src/mc/mc_private.hpp"
+#include "src/mc/remote/RemoteSimulation.hpp"
+#include <xbt/asserts.h>
+#include <xbt/log.h>
+
+XBT_LOG_NEW_DEFAULT_SUBCATEGORY(mc_api, mc, "Logging specific to MC Fasade APIs ");
+
+namespace simgrid {
+namespace mc {
+
+void mc_api::initialize(char** argv)
+{
+  simgrid::mc::session = new simgrid::mc::Session([argv] {
+    int i = 1;
+    while (argv[i] != nullptr && argv[i][0] == '-')
+      i++;
+    xbt_assert(argv[i] != nullptr,
+               "Unable to find a binary to exec on the command line. Did you only pass config flags?");
+    execvp(argv[i], argv + i);
+    xbt_die("The model-checked process failed to exec(): %s", strerror(errno));
+  });
+}
+
+void mc_api::s_initialize() const
+{
+  session->initialize();
+}
+
+void mc_api::create_model_checker(std::unique_ptr<RemoteSimulation> remote_simulation, int sockfd)
+{
+
+}
+
+ModelChecker* mc_api::get_model_checker() const
+{
+    return mc_model_checker;
+}
+
+void mc_api::mc_inc_visited_states() const
+{
+  mc_model_checker->visited_states++;
+}
+
+void mc_api::mc_inc_executed_trans() const
+{
+  mc_model_checker->executed_transitions++;
+}
+
+unsigned long mc_api::mc_get_visited_states() const
+{
+  return mc_model_checker->visited_states;
+}
+
+unsigned long mc_api::mc_get_executed_trans() const
+{
+  return mc_model_checker->executed_transitions;
+}
+
+bool mc_api::mc_check_deadlock() const
+{
+  return mc_model_checker->checkDeadlock();
+}
+
+std::vector<simgrid::mc::ActorInformation>& mc_api::get_actors() const
+{
+  return mc_model_checker->get_remote_simulation().actors();
+}
+
+bool mc_api::actor_is_enabled(aid_t pid) const
+{
+  return session->actor_is_enabled(pid);
+}
+
+void mc_api::mc_assert(bool notNull, const char* message) const
+{
+  if (notNull)
+    xbt_assert(mc_model_checker == nullptr, message);
+  else
+    xbt_assert(mc_model_checker != nullptr, message);
+}
+
+bool mc_api::mc_is_null() const
+{
+  auto is_null = (mc_model_checker == nullptr) ? true : false;
+  return is_null;
+}
+
+Checker* mc_api::mc_get_checker() const
+{
+  return mc_model_checker->getChecker();
+}
+
+RemoteSimulation& mc_api::mc_get_remote_simulation() const
+{
+  return mc_model_checker->get_remote_simulation();
+}
+
+void mc_api::handle_simcall(Transition const& transition) const
+{
+  mc_model_checker->handle_simcall(transition);
+}
+
+void mc_api::mc_wait_for_requests() const
+{
+  mc_model_checker->wait_for_requests();
+}
+
+void mc_api::mc_exit(int status) const
+{
+  mc_model_checker->exit(status);
+}
+
+std::string const& mc_api::mc_get_host_name(std::string const& hostname) const
+{
+  return mc_model_checker->get_host_name(hostname); 
+}
+
+PageStore& mc_api::mc_page_store() const
+{
+  return mc_model_checker->page_store();
+}
+
+void mc_api::mc_cleanup()
+{
+}
+
+void mc_api::s_close() const
+{
+  session->close();
+}
+
+void mc_api::s_restore_initial_state() const
+{
+  session->restore_initial_state();
+}
+
+void mc_api::execute(Transition const& transition)
+{
+  session->execute(transition);
+}
+
+void mc_api::s_log_state() const
+{
+  session->log_state();
+}
+
+} // namespace mc
+} // namespace simgrid

--- a/src/mc/mc_api.cpp
+++ b/src/mc/mc_api.cpp
@@ -5,6 +5,7 @@
 #include "src/mc/mc_smx.hpp"
 #include "src/mc/remote/RemoteSimulation.hpp"
 #include "src/mc/mc_record.hpp"
+#include "src/mc/mc_comm_pattern.hpp"
 
 #include <xbt/asserts.h>
 #include <xbt/log.h>
@@ -40,6 +41,16 @@ bool mc_api::actor_is_enabled(aid_t pid) const
 unsigned long mc_api::get_maxpid() const
 {
   return MC_smx_get_maxpid();
+}
+
+void mc_api::copy_incomplete_comm_pattern(const simgrid::mc::State* state) const
+{
+  MC_state_copy_incomplete_communications_pattern((simgrid::mc::State*)state);
+}
+
+void mc_api::copy_index_comm_pattern(const simgrid::mc::State* state) const
+{
+  MC_state_copy_index_communications_pattern((simgrid::mc::State*)state);
 }
 
 void mc_api::s_initialize() const

--- a/src/mc/mc_api.cpp
+++ b/src/mc/mc_api.cpp
@@ -82,14 +82,6 @@ smx_actor_t mc_api::mc_smx_simcall_get_issuer(s_smx_simcall const* req) const
   return MC_smx_simcall_get_issuer(req);
 }
 
-void mc_api::mc_assert(bool notNull, const char* message) const
-{
-  if (notNull)
-    xbt_assert(mc_model_checker == nullptr, message);
-  else
-    xbt_assert(mc_model_checker != nullptr, message);
-}
-
 bool mc_api::mc_is_null() const
 {
   auto is_null = (mc_model_checker == nullptr) ? true : false;

--- a/src/mc/mc_api.cpp
+++ b/src/mc/mc_api.cpp
@@ -3,6 +3,8 @@
 #include "src/mc/Session.hpp"
 #include "src/mc/mc_private.hpp"
 #include "src/mc/remote/RemoteSimulation.hpp"
+#include "src/mc/mc_smx.hpp"
+
 #include <xbt/asserts.h>
 #include <xbt/log.h>
 
@@ -62,6 +64,16 @@ unsigned long mc_api::mc_get_executed_trans() const
 bool mc_api::mc_check_deadlock() const
 {
   return mc_model_checker->checkDeadlock();
+}
+
+void mc_api::mc_show_deadlock() const
+{
+  MC_show_deadlock();
+}
+
+smx_actor_t mc_api::mc_smx_simcall_get_issuer(s_smx_simcall const* req) const
+{
+  return MC_smx_simcall_get_issuer(req);
 }
 
 std::vector<simgrid::mc::ActorInformation>& mc_api::get_actors() const
@@ -125,6 +137,21 @@ PageStore& mc_api::mc_page_store() const
 
 void mc_api::mc_cleanup()
 {
+}
+
+bool mc_api::request_depend(smx_simcall_t req1, smx_simcall_t req2) const
+{
+  return simgrid::mc::request_depend(req1, req2);
+}
+
+std::string mc_api::request_to_string(smx_simcall_t req, int value, RequestType request_type) const
+{
+  return simgrid::mc::request_to_string(req, value, request_type).c_str();
+}
+
+const char * mc_api::simix_simcall_name(e_smx_simcall_t kind) const
+{
+  return SIMIX_simcall_name(kind);
 }
 
 void mc_api::s_close() const

--- a/src/mc/mc_api.cpp
+++ b/src/mc/mc_api.cpp
@@ -2,8 +2,9 @@
 
 #include "src/mc/Session.hpp"
 #include "src/mc/mc_private.hpp"
-#include "src/mc/remote/RemoteSimulation.hpp"
 #include "src/mc/mc_smx.hpp"
+#include "src/mc/remote/RemoteSimulation.hpp"
+#include "src/mc/mc_record.hpp"
 
 #include <xbt/asserts.h>
 #include <xbt/log.h>
@@ -33,7 +34,7 @@ void mc_api::s_initialize() const
 
 ModelChecker* mc_api::get_model_checker() const
 {
-    return mc_model_checker;
+  return mc_model_checker;
 }
 
 void mc_api::mc_inc_visited_states() const
@@ -122,7 +123,7 @@ void mc_api::mc_exit(int status) const
 
 std::string const& mc_api::mc_get_host_name(std::string const& hostname) const
 {
-  return mc_model_checker->get_host_name(hostname); 
+  return mc_model_checker->get_host_name(hostname);
 }
 
 PageStore& mc_api::mc_page_store() const
@@ -130,8 +131,9 @@ PageStore& mc_api::mc_page_store() const
   return mc_model_checker->page_store();
 }
 
-void mc_api::mc_cleanup()
+void mc_api::mc_dump_record_path() const
 {
+  simgrid::mc::dumpRecordPath();
 }
 
 bool mc_api::request_depend(smx_simcall_t req1, smx_simcall_t req2) const
@@ -144,9 +146,14 @@ std::string mc_api::request_to_string(smx_simcall_t req, int value, RequestType 
   return simgrid::mc::request_to_string(req, value, request_type).c_str();
 }
 
-const char * mc_api::simix_simcall_name(e_smx_simcall_t kind) const
+const char* mc_api::simix_simcall_name(e_smx_simcall_t kind) const
 {
   return SIMIX_simcall_name(kind);
+}
+
+bool mc_api::snapshot_equal(const Snapshot* s1, const Snapshot* s2) const
+{
+  return simgrid::mc::snapshot_equal(s1, s2);
 }
 
 void mc_api::s_close() const

--- a/src/mc/mc_api.cpp
+++ b/src/mc/mc_api.cpp
@@ -27,6 +27,16 @@ void mc_api::initialize(char** argv)
   });
 }
 
+std::vector<simgrid::mc::ActorInformation>& mc_api::get_actors() const
+{
+  return mc_model_checker->get_remote_simulation().actors();
+}
+
+bool mc_api::actor_is_enabled(aid_t pid) const
+{
+  return session->actor_is_enabled(pid);
+}
+
 void mc_api::s_initialize() const
 {
   session->initialize();
@@ -70,16 +80,6 @@ void mc_api::mc_show_deadlock() const
 smx_actor_t mc_api::mc_smx_simcall_get_issuer(s_smx_simcall const* req) const
 {
   return MC_smx_simcall_get_issuer(req);
-}
-
-std::vector<simgrid::mc::ActorInformation>& mc_api::get_actors() const
-{
-  return mc_model_checker->get_remote_simulation().actors();
-}
-
-bool mc_api::actor_is_enabled(aid_t pid) const
-{
-  return session->actor_is_enabled(pid);
 }
 
 void mc_api::mc_assert(bool notNull, const char* message) const
@@ -136,6 +136,11 @@ void mc_api::mc_dump_record_path() const
   simgrid::mc::dumpRecordPath();
 }
 
+smx_simcall_t mc_api::mc_state_choose_request(simgrid::mc::State* state) const
+{
+  return MC_state_choose_request(state);
+}
+
 bool mc_api::request_depend(smx_simcall_t req1, smx_simcall_t req2) const
 {
   return simgrid::mc::request_depend(req1, req2);
@@ -144,6 +149,11 @@ bool mc_api::request_depend(smx_simcall_t req1, smx_simcall_t req2) const
 std::string mc_api::request_to_string(smx_simcall_t req, int value, RequestType request_type) const
 {
   return simgrid::mc::request_to_string(req, value, request_type).c_str();
+}
+
+std::string mc_api::request_get_dot_output(smx_simcall_t req, int value) const
+{
+  return simgrid::mc::request_get_dot_output(req, value);
 }
 
 const char* mc_api::simix_simcall_name(e_smx_simcall_t kind) const

--- a/src/mc/mc_api.cpp
+++ b/src/mc/mc_api.cpp
@@ -37,6 +37,11 @@ bool mc_api::actor_is_enabled(aid_t pid) const
   return session->actor_is_enabled(pid);
 }
 
+unsigned long mc_api::get_maxpid() const
+{
+  return MC_smx_get_maxpid();
+}
+
 void mc_api::s_initialize() const
 {
   session->initialize();
@@ -118,11 +123,6 @@ std::string const& mc_api::mc_get_host_name(std::string const& hostname) const
   return mc_model_checker->get_host_name(hostname);
 }
 
-PageStore& mc_api::mc_page_store() const
-{
-  return mc_model_checker->page_store();
-}
-
 void mc_api::mc_dump_record_path() const
 {
   simgrid::mc::dumpRecordPath();
@@ -156,6 +156,12 @@ const char* mc_api::simix_simcall_name(e_smx_simcall_t kind) const
 bool mc_api::snapshot_equal(const Snapshot* s1, const Snapshot* s2) const
 {
   return simgrid::mc::snapshot_equal(s1, s2);
+}
+
+simgrid::mc::Snapshot* mc_api::take_snapshot(int num_state) const
+{
+  auto snapshot = new simgrid::mc::Snapshot(num_state);
+  return snapshot;
 }
 
 void mc_api::s_close() const

--- a/src/mc/mc_api.cpp
+++ b/src/mc/mc_api.cpp
@@ -31,11 +31,6 @@ void mc_api::s_initialize() const
   session->initialize();
 }
 
-void mc_api::create_model_checker(std::unique_ptr<RemoteSimulation> remote_simulation, int sockfd)
-{
-
-}
-
 ModelChecker* mc_api::get_model_checker() const
 {
     return mc_model_checker;

--- a/src/mc/mc_api.hpp
+++ b/src/mc/mc_api.hpp
@@ -43,6 +43,10 @@ public:
   bool actor_is_enabled(aid_t pid) const;
   unsigned long get_maxpid() const;
 
+  // COMM FUNCTIONS
+  void copy_incomplete_comm_pattern(const simgrid::mc::State* state) const;
+  void copy_index_comm_pattern(const simgrid::mc::State* state) const;
+
   // MODEL_CHECKER FUNCTIONS
   ModelChecker* get_model_checker() const;
   void mc_inc_visited_states() const;

--- a/src/mc/mc_api.hpp
+++ b/src/mc/mc_api.hpp
@@ -1,0 +1,71 @@
+#ifndef SIMGRID_MC_API_HPP
+#define SIMGRID_MC_API_HPP
+
+#include <memory>
+#include <vector>
+
+#include "simgrid/forward.h"
+#include "src/mc/mc_forward.hpp"
+#include "xbt/base.h"
+
+namespace simgrid {
+namespace mc {
+
+/*
+** This class aimes to implement FACADE APIs for simgrid. The FACADE layer sits between the CheckerSide
+** (Unfolding_Checker, DPOR, ...) layer and the
+** AppSide layer. The goal is to drill down into the entagled details in the CheckerSide layer and break down the
+** detailes in a way that the CheckerSide eventually
+** be capable to acquire the required information through the FACADE layer rather than the direct access to the AppSide.
+*/
+
+class mc_api {
+private:
+  mc_api() = default;
+
+public:
+  // No copy:
+  mc_api(mc_api const&) = delete;
+  void operator=(mc_api const&) = delete;
+
+  static mc_api& get()
+  {
+    static mc_api mcapi;
+    return mcapi;
+  }
+
+  void initialize(char** argv);
+
+  // MODEL_CHECKER FUNCTIONS
+  void create_model_checker(std::unique_ptr<RemoteSimulation> remote_simulation, int sockfd);
+  ModelChecker* get_model_checker() const;
+  void mc_inc_visited_states() const;
+  void mc_inc_executed_trans() const;
+  unsigned long mc_get_visited_states() const;
+  unsigned long mc_get_executed_trans() const;
+  bool mc_check_deadlock() const;
+  std::vector<simgrid::mc::ActorInformation>& get_actors() const;
+  bool actor_is_enabled(aid_t pid) const;
+  void mc_assert(bool notNull, const char* message = "") const;
+  bool mc_is_null() const;
+  Checker* mc_get_checker() const;
+  RemoteSimulation& mc_get_remote_simulation() const;
+  void handle_simcall(Transition const& transition) const;
+  void mc_wait_for_requests() const;
+  void mc_exit(int status) const;
+  std::string const& mc_get_host_name(std::string const& hostname) const;
+  PageStore& mc_page_store() const;
+  void mc_cleanup();
+
+  // SESSION FUNCTIONS
+  void s_initialize() const;
+  void s_close() const;
+  void s_restore_initial_state() const;
+  void execute(Transition const& transition);
+  void s_log_state() const;
+};
+
+} // namespace mc
+} // namespace simgrid
+
+#endif

--- a/src/mc/mc_api.hpp
+++ b/src/mc/mc_api.hpp
@@ -6,6 +6,7 @@
 
 #include "simgrid/forward.h"
 #include "src/mc/mc_forward.hpp"
+#include "src/mc/mc_request.hpp"
 #include "xbt/base.h"
 
 namespace simgrid {
@@ -44,6 +45,8 @@ public:
   unsigned long mc_get_visited_states() const;
   unsigned long mc_get_executed_trans() const;
   bool mc_check_deadlock() const;
+  void mc_show_deadlock() const;
+  smx_actor_t mc_smx_simcall_get_issuer(s_smx_simcall const* req) const;
   std::vector<simgrid::mc::ActorInformation>& get_actors() const;
   bool actor_is_enabled(aid_t pid) const;
   void mc_assert(bool notNull, const char* message = "") const;
@@ -56,6 +59,11 @@ public:
   std::string const& mc_get_host_name(std::string const& hostname) const;
   PageStore& mc_page_store() const;
   void mc_cleanup();
+
+  // SIMCALL FUNCTIONS
+  bool request_depend(smx_simcall_t req1, smx_simcall_t req2) const;
+  std::string request_to_string(smx_simcall_t req, int value, RequestType request_type) const;
+  const char *simix_simcall_name(e_smx_simcall_t kind) const;
 
   // SESSION FUNCTIONS
   void s_initialize() const;

--- a/src/mc/mc_api.hpp
+++ b/src/mc/mc_api.hpp
@@ -41,6 +41,7 @@ public:
   // ACTOR FUNCTIONS  
   std::vector<simgrid::mc::ActorInformation>& get_actors() const;
   bool actor_is_enabled(aid_t pid) const;
+  unsigned long get_maxpid() const;
 
   // MODEL_CHECKER FUNCTIONS
   ModelChecker* get_model_checker() const;
@@ -58,7 +59,6 @@ public:
   void mc_wait_for_requests() const;
   void mc_exit(int status) const;
   std::string const& mc_get_host_name(std::string const& hostname) const;
-  PageStore& mc_page_store() const;
   void mc_dump_record_path() const;
   smx_simcall_t mc_state_choose_request(simgrid::mc::State* state) const;
 
@@ -70,6 +70,7 @@ public:
 
   // SNAPSHOT FUNCTIONS
   bool snapshot_equal(const Snapshot* s1, const Snapshot* s2) const;
+  simgrid::mc::Snapshot* take_snapshot(int num_state) const;
 
   // SESSION FUNCTIONS
   void s_initialize() const;

--- a/src/mc/mc_api.hpp
+++ b/src/mc/mc_api.hpp
@@ -57,12 +57,15 @@ public:
   void mc_exit(int status) const;
   std::string const& mc_get_host_name(std::string const& hostname) const;
   PageStore& mc_page_store() const;
-  void mc_cleanup();
+  void mc_dump_record_path() const;
 
   // SIMCALL FUNCTIONS
   bool request_depend(smx_simcall_t req1, smx_simcall_t req2) const;
   std::string request_to_string(smx_simcall_t req, int value, RequestType request_type) const;
   const char *simix_simcall_name(e_smx_simcall_t kind) const;
+
+  // SNAPSHOT FUNCTIONS
+  bool snapshot_equal(const Snapshot* s1, const Snapshot* s2) const;
 
   // SESSION FUNCTIONS
   void s_initialize() const;

--- a/src/mc/mc_api.hpp
+++ b/src/mc/mc_api.hpp
@@ -7,6 +7,7 @@
 #include "simgrid/forward.h"
 #include "src/mc/mc_forward.hpp"
 #include "src/mc/mc_request.hpp"
+#include "src/mc/mc_state.hpp"
 #include "xbt/base.h"
 
 namespace simgrid {
@@ -37,6 +38,10 @@ public:
 
   void initialize(char** argv);
 
+  // ACTOR FUNCTIONS  
+  std::vector<simgrid::mc::ActorInformation>& get_actors() const;
+  bool actor_is_enabled(aid_t pid) const;
+
   // MODEL_CHECKER FUNCTIONS
   ModelChecker* get_model_checker() const;
   void mc_inc_visited_states() const;
@@ -46,8 +51,6 @@ public:
   bool mc_check_deadlock() const;
   void mc_show_deadlock() const;
   smx_actor_t mc_smx_simcall_get_issuer(s_smx_simcall const* req) const;
-  std::vector<simgrid::mc::ActorInformation>& get_actors() const;
-  bool actor_is_enabled(aid_t pid) const;
   void mc_assert(bool notNull, const char* message = "") const;
   bool mc_is_null() const;
   Checker* mc_get_checker() const;
@@ -58,10 +61,12 @@ public:
   std::string const& mc_get_host_name(std::string const& hostname) const;
   PageStore& mc_page_store() const;
   void mc_dump_record_path() const;
+  smx_simcall_t mc_state_choose_request(simgrid::mc::State* state) const;
 
   // SIMCALL FUNCTIONS
   bool request_depend(smx_simcall_t req1, smx_simcall_t req2) const;
   std::string request_to_string(smx_simcall_t req, int value, RequestType request_type) const;
+  std::string request_get_dot_output(smx_simcall_t req, int value) const;
   const char *simix_simcall_name(e_smx_simcall_t kind) const;
 
   // SNAPSHOT FUNCTIONS

--- a/src/mc/mc_api.hpp
+++ b/src/mc/mc_api.hpp
@@ -38,7 +38,6 @@ public:
   void initialize(char** argv);
 
   // MODEL_CHECKER FUNCTIONS
-  void create_model_checker(std::unique_ptr<RemoteSimulation> remote_simulation, int sockfd);
   ModelChecker* get_model_checker() const;
   void mc_inc_visited_states() const;
   void mc_inc_executed_trans() const;

--- a/src/mc/mc_api.hpp
+++ b/src/mc/mc_api.hpp
@@ -51,7 +51,6 @@ public:
   bool mc_check_deadlock() const;
   void mc_show_deadlock() const;
   smx_actor_t mc_smx_simcall_get_issuer(s_smx_simcall const* req) const;
-  void mc_assert(bool notNull, const char* message = "") const;
   bool mc_is_null() const;
   Checker* mc_get_checker() const;
   RemoteSimulation& mc_get_remote_simulation() const;

--- a/src/mc/mc_base.cpp
+++ b/src/mc/mc_base.cpp
@@ -70,12 +70,14 @@ void wait_for_requests()
 // Called from both MCer and MCed:
 bool actor_is_enabled(smx_actor_t actor)
 {
+// #del
 #if SIMGRID_HAVE_MC
   // If in the MCer, ask the client app since it has all the data
   if (mc_model_checker != nullptr) {
     return simgrid::mc::session->actor_is_enabled(actor->get_pid());
   }
 #endif
+// #
 
   // Now, we are in the client app, no need for remote memory reading.
   smx_simcall_t req = &actor->simcall_;

--- a/src/mc/mc_state.cpp
+++ b/src/mc/mc_state.cpp
@@ -7,11 +7,12 @@
 #include "src/mc/mc_comm_pattern.hpp"
 #include "src/mc/mc_config.hpp"
 #include "src/mc/mc_request.hpp"
-#include "src/mc/mc_smx.hpp"
+#include "src/mc/mc_api.hpp"
 
 #include <boost/range/algorithm.hpp>
 
 using simgrid::mc::remote;
+using mcapi = simgrid::mc::mc_api;
 
 namespace simgrid {
 namespace mc {
@@ -19,11 +20,12 @@ namespace mc {
 State::State(unsigned long state_number) : num_(state_number)
 {
   this->internal_comm_.clear();
-
-  actor_states_.resize(MC_smx_get_maxpid());
+  auto maxpid = mcapi::get().get_maxpid();
+  actor_states_.resize(maxpid);
   /* Stateful model checking */
   if ((_sg_mc_checkpoint > 0 && (state_number % _sg_mc_checkpoint == 0)) || _sg_mc_termination) {
-    system_state_ = std::make_shared<simgrid::mc::Snapshot>(num_);
+    auto snapshot_ptr = mcapi::get().take_snapshot(num_);
+    system_state_ = std::shared_ptr<simgrid::mc::Snapshot>(snapshot_ptr);
     if (_sg_mc_comms_determinism || _sg_mc_send_determinism) {
       MC_state_copy_incomplete_communications_pattern(this);
       MC_state_copy_index_communications_pattern(this);

--- a/src/mc/mc_state.cpp
+++ b/src/mc/mc_state.cpp
@@ -4,7 +4,7 @@
  * under the terms of the license (GNU LGPL) which comes with this package. */
 
 #include "src/mc/mc_state.hpp"
-#include "src/mc/mc_comm_pattern.hpp"
+// #include "src/mc/mc_comm_pattern.hpp"
 #include "src/mc/mc_config.hpp"
 #include "src/mc/mc_request.hpp"
 #include "src/mc/mc_api.hpp"
@@ -27,8 +27,8 @@ State::State(unsigned long state_number) : num_(state_number)
     auto snapshot_ptr = mcapi::get().take_snapshot(num_);
     system_state_ = std::shared_ptr<simgrid::mc::Snapshot>(snapshot_ptr);
     if (_sg_mc_comms_determinism || _sg_mc_send_determinism) {
-      MC_state_copy_incomplete_communications_pattern(this);
-      MC_state_copy_index_communications_pattern(this);
+      mcapi::get().copy_incomplete_comm_pattern(this);
+      mcapi::get().copy_index_comm_pattern(this);
     }
   }
 }

--- a/tools/cmake/DefinePackages.cmake
+++ b/tools/cmake/DefinePackages.cmake
@@ -611,7 +611,7 @@ set(MC_SRC
   src/mc/checker/SimcallInspector.hpp
   src/mc/checker/LivenessChecker.cpp
   src/mc/checker/LivenessChecker.hpp
-  
+
   src/mc/inspect/DwarfExpression.hpp
   src/mc/inspect/DwarfExpression.cpp
   src/mc/inspect/Frame.hpp
@@ -661,6 +661,8 @@ set(MC_SRC
   src/mc/mc_comm_pattern.cpp
   src/mc/mc_comm_pattern.hpp
   src/mc/compare.cpp
+  src/mc/mc_api.cpp
+  src/mc/mc_api.hpp
   src/mc/mc_hash.hpp
   src/mc/mc_hash.cpp
   src/mc/mc_ignore.hpp


### PR DESCRIPTION
I changed my approach. The "State" instance in model checker keeps all of the required fields but assignment to these fields come from calling APIs of mc_api class. The "State" instanced don't retrieve data directly from the kernel part.   