### PR TITLE
Add docker images to ci

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,6 +35,5 @@ jobs:
           cd tools/docker
           make stable
           make all
-          make tuto-mc
           make push
       

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,4 +36,3 @@ jobs:
           make stable
           make all
           make push
-      

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ name: Docker
 on:
   workflow_dispatch:
   schedule:
-    - cron: '41 20 * * 0'
+    - cron: '42 18 * * 0'
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -28,16 +28,18 @@ jobs:
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
-   #   - name: Log into registry ${{ env.REGISTRY }}
-   #     uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
-   #     with:
-   #       registry: ${{ env.REGISTRY }}
-   #       username: ${{ github.actor }}
-   #       password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build
         run: |
           cd tools/docker
           make stable
           make all
+          make tuto-mc
+          make push
       

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,10 +10,6 @@ on:
   schedule:
     - cron: '42 18 * * 0'
 
-env:
-  # Use docker.io for Docker Hub if empty
-  REGISTRY: ghcr.io
-
 jobs:
   build:
 
@@ -29,11 +25,10 @@ jobs:
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v1
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: build
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,6 +38,6 @@ jobs:
       - name: build
         run: |
           cd tools/docker
+          make stable
           make all
-          #make push
       

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -16,7 +16,7 @@ all: build-deps unstable tuto-s4u tuto-smpi
 stable:
 	# docker build -f Dockerfile.stable --build-arg DLURL=/simgrid/simgrid/-/archive/v3.28/simgrid-v3.28.tar.gz -t simgrid/stable:latest -t simgrid/stable:v3.25 . |tee stable.log
 	export last_tag=$$(wget https://framagit.org/simgrid/simgrid/tags 2>/dev/null -O - | grep /simgrid/simgrid/-/tags/v | head -n1  | sed 's/[^>]*>//' | sed 's/<.*//'); \
-	export DLURL= $$(echo "/simgrid/simgrid/-/archive/${last_tag}/simgrid-${last_tag}.tar.gz")\
+	export DLURL="/simgrid/simgrid/-/archive/$${last_tag}/simgrid-${last_tag}.tar.gz"\
  	echo "DLURL=$$DLURL";\
 	docker build -f Dockerfile.stable \
 	         --build-arg DLURL=$${DLURL} \

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -11,7 +11,7 @@ default:
 	@echo "All our images are based on debian:testing"
 	@echo "Also possible: DOCKER_EXTRA=--no-cache make unstable"
 
-all: build-deps unstable tuto-s4u tuto-smpi
+all: build-deps unstable tuto-s4u tuto-smpi tuto-mc
 
 stable:
 	# docker build -f Dockerfile.stable --build-arg DLURL=/simgrid/simgrid/-/archive/v3.28/simgrid-v3.28.tar.gz -t simgrid/stable:latest -t simgrid/stable:v3.25 . |tee stable.log

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -18,9 +18,9 @@ stable:
 	export last_tag=$$(wget https://framagit.org/simgrid/simgrid/tags 2>/dev/null -O - | grep /simgrid/simgrid/-/tags/v | head -n1  | sed 's/[^>]*>//' | sed 's/<.*//'); \
  	echo "DLURL=/simgrid/simgrid/-/archive/$${last_tag}/simgrid-$${last_tag}.tar.gz";\
 	docker build -f Dockerfile.stable \
-	         --build-arg DLURL=$${DLURL} \
+	         --build-arg DLURL=/simgrid/simgrid/-/archive/$${last_tag}/simgrid-$${last_tag}.tar.gz \
 		 -t simgrid/stable:latest \
-                 -t simgrid/stable:"/simgrid/simgrid/-/archive/$${last_tag}/simgrid-$${last_tag}.tar.gz" \
+                 -t simgrid/stable:$${last_tag} \
 		 $(DOCKER_EXTRA) \
                  . | tee stable.log
 

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -16,7 +16,7 @@ all: build-deps unstable tuto-s4u tuto-smpi
 stable:
 	# docker build -f Dockerfile.stable --build-arg DLURL=/simgrid/simgrid/-/archive/v3.28/simgrid-v3.28.tar.gz -t simgrid/stable:latest -t simgrid/stable:v3.25 . |tee stable.log
 	export last_tag=$$(wget https://framagit.org/simgrid/simgrid/tags 2>/dev/null -O - | grep /simgrid/simgrid/-/tags/v | head -n1  | sed 's/[^>]*>//' | sed 's/<.*//'); \
-	export DLURL="/simgrid/simgrid/-/archive/$${last_tag}/simgrid-${last_tag}.tar.gz"\
+	export DLURL=$$(echo "/simgrid/simgrid/-/archive/$${last_tag}/simgrid-${last_tag}.tar.gz")\
  	echo "DLURL=$$DLURL";\
 	docker build -f Dockerfile.stable \
 	         --build-arg DLURL=$${DLURL} \

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -16,12 +16,11 @@ all: build-deps unstable tuto-s4u tuto-smpi
 stable:
 	# docker build -f Dockerfile.stable --build-arg DLURL=/simgrid/simgrid/-/archive/v3.28/simgrid-v3.28.tar.gz -t simgrid/stable:latest -t simgrid/stable:v3.25 . |tee stable.log
 	export last_tag=$$(wget https://framagit.org/simgrid/simgrid/tags 2>/dev/null -O - | grep /simgrid/simgrid/-/tags/v | head -n1  | sed 's/[^>]*>//' | sed 's/<.*//'); \
-	export DLURL=$$(echo "/simgrid/simgrid/-/archive/$${last_tag}/simgrid-$${last_tag}.tar.gz")\
- 	echo "DLURL=$$DLURL";\
+ 	echo "DLURL=/simgrid/simgrid/-/archive/$${last_tag}/simgrid-$${last_tag}.tar.gz";\
 	docker build -f Dockerfile.stable \
 	         --build-arg DLURL=$${DLURL} \
 		 -t simgrid/stable:latest \
-                 -t simgrid/stable:$${last_tag} \
+                 -t simgrid/stable:"/simgrid/simgrid/-/archive/$${last_tag}/simgrid-$${last_tag}.tar.gz" \
 		 $(DOCKER_EXTRA) \
                  . | tee stable.log
 

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -16,7 +16,7 @@ all: build-deps unstable tuto-s4u tuto-smpi
 stable:
 	# docker build -f Dockerfile.stable --build-arg DLURL=/simgrid/simgrid/-/archive/v3.28/simgrid-v3.28.tar.gz -t simgrid/stable:latest -t simgrid/stable:v3.25 . |tee stable.log
 	export last_tag=$$(wget https://framagit.org/simgrid/simgrid/tags 2>/dev/null -O - | grep /simgrid/simgrid/-/tags/v | head -n1  | sed 's/[^>]*>//' | sed 's/<.*//'); \
-	export DLURL= "/simgrid/simgrid/-/archive/${last_tag}/simgrid-${last_tag}.tar.gz"\
+	export DLURL= $(echo "/simgrid/simgrid/-/archive/${last_tag}/simgrid-${last_tag}.tar.gz")\
  	echo "DLURL=$$DLURL";\
 	docker build -f Dockerfile.stable \
 	         --build-arg DLURL=$${DLURL} \

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -14,10 +14,10 @@ default:
 all: build-deps unstable tuto-s4u tuto-smpi
 
 stable:
-	# docker build -f Dockerfile.stable --build-arg DLURL=/simgrid/simgrid/uploads/0365f13697fb26eae8c20fc234c5af0e/SimGrid-3.25.tar.gz -t simgrid/stable:latest -t simgrid/stable:v3.25 . |tee stable.log
+	# docker build -f Dockerfile.stable --build-arg DLURL=/simgrid/simgrid/-/archive/v3.28/simgrid-v3.28.tar.gz -t simgrid/stable:latest -t simgrid/stable:v3.25 . |tee stable.log
 	export last_tag=$$(wget https://framagit.org/simgrid/simgrid/tags 2>/dev/null -O - | grep /simgrid/simgrid/-/tags/v | head -n1  | sed 's/[^>]*>//' | sed 's/<.*//'); \
-	export DLURL=$$(wget https://framagit.org/simgrid/simgrid/tags/$${last_tag} 2>/dev/null -O - | grep simgrid- | perl -pe 's/.*?<a href="(\/simgrid[^ ]*tar.gz)".*/$1/'); \
-  echo "DLURL=$$DLURL";\
+	export DLURL= "/simgrid/simgrid/-/archive/${last_tag}/simgrid-${last_tag}.tar.gz"\
+ 	echo "DLURL=$$DLURL";\
 	docker build -f Dockerfile.stable \
 	         --build-arg DLURL=$${DLURL} \
 		 -t simgrid/stable:latest \

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -16,7 +16,7 @@ all: build-deps unstable tuto-s4u tuto-smpi
 stable:
 	# docker build -f Dockerfile.stable --build-arg DLURL=/simgrid/simgrid/-/archive/v3.28/simgrid-v3.28.tar.gz -t simgrid/stable:latest -t simgrid/stable:v3.25 . |tee stable.log
 	export last_tag=$$(wget https://framagit.org/simgrid/simgrid/tags 2>/dev/null -O - | grep /simgrid/simgrid/-/tags/v | head -n1  | sed 's/[^>]*>//' | sed 's/<.*//'); \
-	export DLURL=$$(echo "/simgrid/simgrid/-/archive/$${last_tag}/simgrid-${last_tag}.tar.gz")\
+	export DLURL=$$(echo "/simgrid/simgrid/-/archive/$${last_tag}/simgrid-$${last_tag}.tar.gz")\
  	echo "DLURL=$$DLURL";\
 	docker build -f Dockerfile.stable \
 	         --build-arg DLURL=$${DLURL} \

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -16,7 +16,7 @@ all: build-deps unstable tuto-s4u tuto-smpi
 stable:
 	# docker build -f Dockerfile.stable --build-arg DLURL=/simgrid/simgrid/-/archive/v3.28/simgrid-v3.28.tar.gz -t simgrid/stable:latest -t simgrid/stable:v3.25 . |tee stable.log
 	export last_tag=$$(wget https://framagit.org/simgrid/simgrid/tags 2>/dev/null -O - | grep /simgrid/simgrid/-/tags/v | head -n1  | sed 's/[^>]*>//' | sed 's/<.*//'); \
-	export DLURL= $(echo "/simgrid/simgrid/-/archive/${last_tag}/simgrid-${last_tag}.tar.gz")\
+	export DLURL= $$(echo "/simgrid/simgrid/-/archive/${last_tag}/simgrid-${last_tag}.tar.gz")\
  	echo "DLURL=$$DLURL";\
 	docker build -f Dockerfile.stable \
 	         --build-arg DLURL=$${DLURL} \


### PR DESCRIPTION
Build is setup once a week (sundays) for all images in tools/docker, using the makefile, or on demand.
Fixes the makefile for stable (and adds tuto-mc to the all target)

Please squash before merging.

***Before merging*** : needs secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN to have been generated and stored in the repo options ( check https://docs.docker.com/docker-hub/access-tokens/ and https://github.com/Azure/actions-workflow-samples/blob/master/assets/create-secrets-for-GitHub-workflows.md )

pushing was not tested, obviously.. so it may fail at start