### PR TITLE
Ensure a final fPIC in case CMDARGS has a fPIE

### DIFF
--- a/src/smpi/smpicc.in
+++ b/src/smpi/smpicc.in
@@ -93,6 +93,10 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+if [ "x@WIN32@" != "x1" ]; then
+    list_add CMDARGS "-fPIC"
+fi
+
 list_set CMDLINE "${CC}"
 list_add_not_empty CMDLINE "${CFLAGS}"
 list_add_not_empty CMDLINE "${INCLUDEARGS}"

--- a/src/smpi/smpicc.in
+++ b/src/smpi/smpicc.in
@@ -29,7 +29,6 @@ if [ "x@WIN32@" = "x1" ]; then
     list_add CFLAGS "-include" "@includedir@/smpi/smpi_main.h"
     list_add LINKARGS "@libdir@\libsimgrid.dll"
 elif [ "x@APPLE@" = "x1" ]; then
-    list_add CFLAGS "-fPIC"
     if [ "x${SMPI_PRETEND_CC}" = "x" ]; then
        list_add CFLAGS "-include" "@includedir@/smpi/smpi_helpers.h"
        list_add LINKARGS "-shared"
@@ -40,7 +39,6 @@ elif [ "x@APPLE@" = "x1" ]; then
       list_add LINKARGS "-lsimgrid" "-lm" ${LINKER_UNDEFINED_ERROR:+"-Wl,-undefined,error"}
     fi
 else
-    list_add CFLAGS "-fPIC"
     if [ "x${SMPI_PRETEND_CC}" = "x" ]; then
        list_add CFLAGS "-include" "@includedir@/smpi/smpi_helpers.h"
        list_add LINKARGS "-shared"

--- a/src/smpi/smpicxx.in
+++ b/src/smpi/smpicxx.in
@@ -90,6 +90,10 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+if [ "x@WIN32@" != "x1" ]; then
+    list_add CMDARGS "-fPIC"
+fi
+
 list_set CMDLINE "${CXX}"
 list_add_not_empty CMDLINE "${CXXFLAGS}"
 list_add_not_empty CMDLINE "${INCLUDEARGS}"

--- a/src/smpi/smpicxx.in
+++ b/src/smpi/smpicxx.in
@@ -29,7 +29,6 @@ if [ "x@WIN32@" = "x1" ]; then
     list_add CXXFLAGS "-include" "@includedir@/smpi/smpi_main.h"
     list_add LINKARGS "@libdir@\libsimgrid.dll"
 elif [ "x@APPLE@" = "x1" ]; then
-    list_add CXXFLAGS "-fPIC"
     if [ "x${SMPI_PRETEND_CC}" = "x" ]; then
        list_add CXXFLAGS "-include" "@includedir@/smpi/smpi_helpers.h"
        list_add LINKARGS "-shared"
@@ -40,7 +39,6 @@ elif [ "x@APPLE@" = "x1" ]; then
       list_add LINKARGS "-lsimgrid" "-lm" ${LINKER_UNDEFINED_ERROR:+"-Wl,-undefined,error"}
     fi
 else
-    list_add CXXFLAGS "-fPIC"
     if [ "x${SMPI_PRETEND_CC}" = "x" ]; then
        list_add CXXFLAGS "-include" "@includedir@/smpi/smpi_helpers.h"
        list_add LINKARGS "-shared"


### PR DESCRIPTION
This changes the order of the CMDLINE to place the CFLAGS after CMDARGS.

Useful when CMDARGS has an fPIE (coming from a CMake POSITION_INDEPENDENT_CODE, for example), this will ensure a fPIC that may be present in CFLAGS to be after the fPIE in CMDARGS.