### PR TITLE
Fix bug when suspend() after resume() didn't work

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -105,7 +105,7 @@ foreach (example activityset-testany activityset-waitany activityset-waitall act
                  dht-chord dht-kademlia
                  energy-exec energy-boot energy-link energy-vm energy-exec-ptask energy-wifi
                  engine-filtering engine-run-partial
-                 exec-async exec-basic exec-dvfs exec-remote exec-waitfor exec-dependent exec-unassigned
+                 exec-async exec-basic exec-dvfs exec-remote exec-suspend exec-waitfor exec-dependent exec-unassigned
                  exec-ptask-multicore exec-ptask-multicore-latency exec-cpu-nonlinear exec-cpu-factors exec-failure exec-threads
                  maestro-set
                  mc-bugged1 mc-bugged2 mc-centralized-mutex mc-electric-fence mc-failing-assert

--- a/examples/cpp/exec-suspend/s4u-exec-suspend.cpp
+++ b/examples/cpp/exec-suspend/s4u-exec-suspend.cpp
@@ -1,0 +1,68 @@
+/* Copyright (c) 2017-2024. The SimGrid Team. All rights reserved.          */
+
+/* This program is free software; you can redistribute it and/or modify it
+ * under the terms of the license (GNU LGPL) which comes with this package. */
+
+#include "simgrid/s4u.hpp"
+
+XBT_LOG_NEW_DEFAULT_CATEGORY(exec_suspend, "Messages specific for this task example");
+
+namespace sg4 = simgrid::s4u;
+
+static void suspend_activity_for(simgrid::s4u::ExecPtr activity, double seconds)
+{
+  activity->suspend();
+  double remaining_computations_before_sleep = activity->get_remaining();
+  sg4::this_actor::sleep_for(seconds);
+  activity->resume();
+
+  // Sanity check: remaining computations have to be the same before and after this period
+  XBT_INFO("Activity hasn't advanced: %s. (remaining before sleep: %f, remaining after sleep: %f)",
+           remaining_computations_before_sleep == activity->get_remaining() ? "yes" : "no",
+           remaining_computations_before_sleep, activity->get_remaining());
+}
+
+static void executor()
+{
+  double computation_amount = sg4::this_actor::get_host()->get_speed();
+
+  // Execution will take 3 seconds
+  auto activity = sg4::this_actor::exec_init(3 * computation_amount);
+
+  // Add functions to be called when the activity is resumed or suspended
+  activity->on_this_suspend_cb(
+      [](const sg4::Exec& t) { XBT_INFO("Task is suspended (remaining: %f)", t.get_remaining()); });
+
+  activity->on_this_resume_cb(
+      [](const sg4::Exec& t) { XBT_INFO("Task is resumed (remaining: %f)", t.get_remaining()); });
+
+  // The first second of the execution
+  activity->start();
+  sg4::this_actor::sleep_for(1);
+
+  // Suspend the activity for 10 seconds
+  suspend_activity_for(activity, 10);
+
+  // Run the activity for one second
+  sg4::this_actor::sleep_for(1);
+
+  // Suspend the activity for the second time
+  suspend_activity_for(activity, 10);
+
+  // Finish execution
+  activity->wait();
+  XBT_INFO("Finished");
+}
+
+int main(int argc, char* argv[])
+{
+  sg4::Engine e(&argc, argv);
+  e.load_platform(argv[1]);
+
+  auto* tremblay = e.host_by_name("Tremblay");
+  sg4::Actor::create("executor", tremblay, executor);
+
+  // Start the simulation
+  e.run();
+  return 0;
+}

--- a/examples/cpp/exec-suspend/s4u-exec-suspend.tesh
+++ b/examples/cpp/exec-suspend/s4u-exec-suspend.tesh
@@ -1,0 +1,10 @@
+#!/usr/bin/env tesh
+
+$ ${bindir:=.}/s4u-exec-suspend ${platfdir}/small_platform.xml
+> [Tremblay:executor:(1) 1.000000] [exec_suspend/INFO] Task is suspended (remaining: 196190000.000000)
+> [Tremblay:executor:(1) 11.000000] [exec_suspend/INFO] Task is resumed (remaining: 196190000.000000)
+> [Tremblay:executor:(1) 11.000000] [exec_suspend/INFO] Activity hasn't advanced: yes. (remaining before sleep: 196190000.000000, remaining after sleep: 196190000.000000)
+> [Tremblay:executor:(1) 12.000000] [exec_suspend/INFO] Task is suspended (remaining: 98095000.000000)
+> [Tremblay:executor:(1) 22.000000] [exec_suspend/INFO] Task is resumed (remaining: 98095000.000000)
+> [Tremblay:executor:(1) 22.000000] [exec_suspend/INFO] Activity hasn't advanced: yes. (remaining before sleep: 98095000.000000, remaining after sleep: 98095000.000000)
+> [Tremblay:executor:(1) 23.000000] [exec_suspend/INFO] Finished

--- a/src/s4u/s4u_Activity.cpp
+++ b/src/s4u/s4u_Activity.cpp
@@ -170,6 +170,7 @@ Activity* Activity::resume()
   if (state_ == State::STARTED)
     pimpl_->resume();
 
+  suspended_ = false;
   return this;
 }
 


### PR DESCRIPTION
If an activity was suspended and resumed in code several times, after the second suspend() the activity wasn't actually suspended(), and the remaining flops continued decreasing over the simulation.