### PR TITLE
Mods to s4u_tasks to allow better tracking of instances throughout

### DIFF
--- a/include/simgrid/s4u/Task.hpp
+++ b/include/simgrid/s4u/Task.hpp
@@ -87,9 +87,8 @@ public:
   {
     return parallelism_degree_.at(instance);
   }
-
+  /** @return Number of instances present in this task. */
   int get_instance_count() const { return this->running_instances_.size(); }
-
   /** @param bytes The amount of bytes this instance has to send to the next instance of this Task
    *  @note This amount is used when the host is different between the dispatcher and the instance doing the work of the
    * Task, or between the instance and the collector. */
@@ -137,7 +136,7 @@ public:
   /** Add a callback fired after a task activity ends.
    * Triggered after the on_this_end function, but before sending tokens to successors.**/
   static void on_completion_cb(const std::function<void(Task*)>& cb) { on_completion.connect(cb); }
-
+  /** Add a callback fired before a task instance activity ends (excluding the dispatcher and the receiver). **/
   static void on_instance_completion_cb(const std::function<void(Task*, const std::string&)>& cb)
   {
     on_instance_completion.connect(cb);

--- a/include/simgrid/s4u/Task.hpp
+++ b/include/simgrid/s4u/Task.hpp
@@ -47,6 +47,7 @@ class XBT_PUBLIC Task {
   xbt::signal<void(Task*)> on_this_start;
   inline static xbt::signal<void(Task*)> on_completion;
   xbt::signal<void(Task*)> on_this_completion;
+  inline static xbt::signal<void(Task*, const std::string&)> on_instance_completion;
 
 protected:
   explicit Task(const std::string& name);
@@ -86,6 +87,9 @@ public:
   {
     return parallelism_degree_.at(instance);
   }
+
+  int get_instance_count() const { return this->running_instances_.size(); }
+
   /** @param bytes The amount of bytes this instance has to send to the next instance of this Task
    *  @note This amount is used when the host is different between the dispatcher and the instance doing the work of the
    * Task, or between the instance and the collector. */
@@ -133,6 +137,11 @@ public:
   /** Add a callback fired after a task activity ends.
    * Triggered after the on_this_end function, but before sending tokens to successors.**/
   static void on_completion_cb(const std::function<void(Task*)>& cb) { on_completion.connect(cb); }
+
+  static void on_instance_completion_cb(const std::function<void(Task*, const std::string&)>& cb)
+  {
+    on_instance_completion.connect(cb);
+  }
 
 #ifndef DOXYGEN
   friend void intrusive_ptr_release(Task* o)

--- a/include/simgrid/s4u/Task.hpp
+++ b/include/simgrid/s4u/Task.hpp
@@ -48,6 +48,7 @@ class XBT_PUBLIC Task {
   inline static xbt::signal<void(Task*)> on_completion;
   xbt::signal<void(Task*)> on_this_completion;
   inline static xbt::signal<void(Task*, const std::string&)> on_instance_completion;
+  xbt::signal<void(Task*, const std::string&)> on_this_instance_completion;
 
 protected:
   explicit Task(const std::string& name);
@@ -136,6 +137,11 @@ public:
   /** Add a callback fired after a task activity ends.
    * Triggered after the on_this_end function, but before sending tokens to successors.**/
   static void on_completion_cb(const std::function<void(Task*)>& cb) { on_completion.connect(cb); }
+  /** Add a callback fired before this task activity ends */
+  void on_this_instance_completion_cb(const std::function<void(Task*, const std::string&)>& func)
+  {
+    on_this_instance_completion.connect(func);
+  };
   /** Add a callback fired before a task instance activity ends (excluding the dispatcher and the receiver). **/
   static void on_instance_completion_cb(const std::function<void(Task*, const std::string&)>& cb)
   {

--- a/src/s4u/s4u_Task.cpp
+++ b/src/s4u/s4u_Task.cpp
@@ -76,6 +76,7 @@ void Task::complete(const std::string& instance)
     while (ready_to_run(next_instance))
       fire(next_instance);
   } else {
+    on_instance_completion(this, instance);
     queued_firings_["collector"]++;
     while (ready_to_run("collector"))
       fire("collector");

--- a/src/s4u/s4u_Task.cpp
+++ b/src/s4u/s4u_Task.cpp
@@ -76,6 +76,7 @@ void Task::complete(const std::string& instance)
     while (ready_to_run(next_instance))
       fire(next_instance);
   } else {
+    on_this_instance_completion(this, instance);
     on_instance_completion(this, instance);
     queued_firings_["collector"]++;
     while (ready_to_run("collector"))


### PR DESCRIPTION
The main idea behind these changes, is to give the user better options while handling instances throughout a simulation. 

## Changes
The Task class was modified to:
1. Allow the user to check the number of instances with `get_instance_count()`.
2. Use a new callback `on_instance_completion_cb()` that is executed when a instance ends. (excluding the dispatcher and the collector).

